### PR TITLE
fix(download): 修复是否可续传链接判断问题

### DIFF
--- a/app/common/methods.py
+++ b/app/common/methods.py
@@ -191,8 +191,6 @@ def getLocalTimeFromGithubApiTime(gmtTimeStr:str):
 def getLinkInfo(url: str, headers: dict, fileName: str = "", verify: bool = cfg.SSLVerify.value, proxy: str = "", followRedirects: bool = True) -> tuple:
     if not proxy:
         proxy = getProxy()
-    headers = headers.copy()
-    headers["Range"] = "bytes=0-"#尝试发送范围请求
     # 使用 stream 请求获取响应
     with httpx.stream("GET", url, headers=headers, verify=verify, proxy=proxy, follow_redirects=followRedirects) as response:
         response.raise_for_status()  # 如果状态码不是 2xx，抛出异常
@@ -203,7 +201,7 @@ def getLinkInfo(url: str, headers: dict, fileName: str = "", verify: bool = cfg.
 
         # 获取文件大小, 判断是否可以分块下载
         # if "content-length" not in head or response.status_code != 200: #状态码为206才是范围请求，200表示服务器拒绝了范围请求同时将发送整个文件
-        if head.get("accept-ranges"):
+        if head.get("accept-ranges") == "bytes":#仅支持bytes单位，服务器可能通过返回值为none的accept-ranges头来明确拒绝范围请求
             fileSize = int(head["content-length"])
         else:
             fileSize = 0


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

<!-- 请取消对应类型的注释 -->

 - Bug 修复
 1.修复可续传链接判断为不可续传链接的bug
 2.修复响应头为  accept-ranges: none  时会被判断为可续传链接的问题。
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注
并不是所有支持续传的链接响应都会返回accept-ranges请求头，会导致有些可续传的链接被判断为不可续传的。原先通过尝试发送访问请求并检查响应码的方法则没有这个问题，这个方法唯一的优点是不用克隆headers
<!-- 请添加任何你认为有帮助的信息 -->