### PR TITLE
将显示信息的刷新速度由1000毫秒改为100毫秒

### DIFF
--- a/app/common/download_task.py
+++ b/app/common/download_task.py
@@ -69,7 +69,7 @@ class DownloadTask(QThread):
         self.fileSize = fileSize
         self.ableToParallelDownload: bool
 
-        self.historySpeed = [0] * 10  # 历史速度 10 秒内的平均速度
+        self.historySpeed = [0] * 100  # 历史速度 10 秒内的平均速度
 
         proxy = getProxy()
 
@@ -418,7 +418,7 @@ class DownloadTask(QThread):
                                 for i in range(4):
                                     self.__reassignWorker(context)  # 新增线程
 
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.1) #加快刷新显示速度
 
         except Exception as e:
             logger.error(f"Supervisor error: {e}")
@@ -449,7 +449,7 @@ class DownloadTask(QThread):
 
             self.speedChanged.emit(avgSpeed)
 
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.1) #加快刷新显示速度
 
     async def __main(self):
         try:


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能 
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注
将原来的下载信息（包括下载速度、剩余时间、已下载大小等）显示的刷新速度由1000毫秒改为100毫秒，达到与IDM类似的显示效果，否则将出现状态同步延迟的现象，例如如果软件在第9002毫秒下载完了文件，由于1000毫秒刷新一次的机制，程序还会再等998毫秒才会显示下载结束，这大大的浪费了我们宝贵的时间以及速度优势（（
<!-- 请添加任何你认为有帮助的信息 -->