### PR TITLE
feat: 新增 User-Agent 请求标头自定义持久化保存 (#309)

### DIFF
--- a/app/services/browser_service.py
+++ b/app/services/browser_service.py
@@ -12,7 +12,7 @@ from orjson import dumps, loads
 
 from app.bases.models import Task, TaskStatus
 from app.services.core_service import coreService
-from app.supports.config import VERSION, cfg
+from app.supports.config import DEFAULT_HEADERS, VERSION, cfg
 from app.supports.recorder import taskRecorder
 from app.supports.signal_bus import signalBus
 from app.supports.utils import getProxies, openFile, openFolder
@@ -283,9 +283,13 @@ class BrowserService(QObject):
 
     def _buildParsePayload(self, rawPayload: dict[str, Any]) -> dict[str, Any]:
         rawPath = rawPayload.get("path")
+        headers = DEFAULT_HEADERS.copy()
+        rawHeaders = rawPayload.get("headers")
+        if isinstance(rawHeaders, dict):
+            headers.update(rawHeaders)
         return {
             "url": self._stringField(rawPayload, "url"),
-            "headers": rawPayload.get("headers") or {},
+            "headers": headers,
             "proxies": getProxies(),
             "path": Path(rawPath) if rawPath else Path(cfg.downloadFolder.value),
             "preBlockNum": self._positiveIntField(rawPayload, "preBlockNum", cfg.preBlockNum.value),

--- a/app/supports/config.py
+++ b/app/supports/config.py
@@ -152,6 +152,16 @@ class HeadersSerializer(ConfigSerializer):
             return DEFAULT_HEADERS
 
 
+class UserAgentValidator(ConfigValidator):
+    def validate(self, value: str) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+    def correct(self, value) -> str:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return DEFAULT_HEADERS["user-agent"]
+
+
 class Config(QConfig):
 
     # 总下载设置
@@ -246,6 +256,12 @@ class Config(QConfig):
     #     HeadersValidator(),
     #     HeadersSerializer(),
     # )
+    userAgent = ConfigItem(
+        "Network",
+        "UserAgent",
+        DEFAULT_HEADERS["user-agent"],
+        UserAgentValidator(),
+    )
 
     # 全局变量
     globalSpeed = 0  # 用于记录每秒下载速度, 单位 KB/s
@@ -278,3 +294,5 @@ attachmentTypes = """3gp 7z aac ace aif arj asf avi bin bz2 dmg exe gz gzip img 
                                  wav wma wmv z zip esd wim msp apk apks apkm cab msp pkg"""
 
 cfg = Config()
+DEFAULT_HEADERS["user-agent"] = cfg.userAgent.value
+cfg.userAgent.valueChanged.connect(lambda value: DEFAULT_HEADERS.__setitem__("user-agent", str(value)))

--- a/app/view/components/setting_cards.py
+++ b/app/view/components/setting_cards.py
@@ -66,6 +66,30 @@ class SpinBoxSettingCard(SettingCard):
             cfg.set(self.configItem, self.spinBox.value() / self.division)
 
 
+class UserAgentSettingCard(SettingCard):
+    def __init__(self, configItem: ConfigItem, parent=None):
+        super().__init__(
+            FluentIcon.DEVELOPER_TOOLS,
+            self.tr("User-Agent"),
+            self.tr("设置下载请求的 User-Agent 标头"),
+            parent,
+        )
+        self.configItem = configItem
+
+        self.lineEdit = LineEdit(self)
+        self.lineEdit.setMinimumWidth(360)
+        self.lineEdit.setText(str(configItem.value or ""))
+
+        self.hBoxLayout.addWidget(self.lineEdit)
+        self.hBoxLayout.addSpacing(24)
+
+        self.lineEdit.editingFinished.connect(self._commitValue)
+        self.configItem.valueChanged.connect(lambda value: self.lineEdit.setText(str(value or "")))
+
+    def _commitValue(self):
+        cfg.set(self.configItem, self.lineEdit.text())
+
+
 class ProxySettingCard(ExpandGroupSettingCard):
     """Custom proxyServer setting card"""
 

--- a/app/view/pages/setting_page.py
+++ b/app/view/pages/setting_page.py
@@ -14,7 +14,7 @@ from app.services.browser_service import BrowserService
 from app.supports.config import cfg, FIREFOX_ADDONS_URL, EDGE_ADDONS_URL, CHROME_ADDONS_URL, AUTHOR_URL, AUTHOR, YEAR, \
     VERSION, FEEDBACK_URL
 from app.supports.utils import openAppLogFolder
-from app.view.components.setting_cards import SpinBoxSettingCard, SelectFolderSettingCard, ProxySettingCard
+from app.view.components.setting_cards import SpinBoxSettingCard, SelectFolderSettingCard, ProxySettingCard, UserAgentSettingCard
 
 if TYPE_CHECKING:
     from app.view.windows.main_window import MainWindow
@@ -116,6 +116,8 @@ class SettingPage(ScrollArea):
             cfg.proxyServer, self.generalDownloadGroup
         )
         self.generalDownloadGroup.addSettingCard(self.proxyServerCard)
+        self.userAgentCard = UserAgentSettingCard(cfg.userAgent, self.generalDownloadGroup)
+        self.generalDownloadGroup.addSettingCard(self.userAgentCard)
         # Browser
         self.browserExtensionCard = SwitchSettingCard(
             FluentIcon.CONNECT,

--- a/features/bittorrent_pack/task.py
+++ b/features/bittorrent_pack/task.py
@@ -751,7 +751,7 @@ class BitTorrentWorker(Worker):
 
 async def _fetchTorrentBytes(payload: dict) -> bytes:
     url = str(payload["url"]).strip()
-    headers = payload.get("headers", DEFAULT_HEADERS)
+    headers = payload.get("headers") or DEFAULT_HEADERS
     proxies = payload.get("proxies", getProxies())
     requestHeaders, requestCookies = splitRequestHeadersAndCookies(headers if isinstance(headers, dict) else DEFAULT_HEADERS)
 

--- a/features/http_pack/pack.py
+++ b/features/http_pack/pack.py
@@ -203,7 +203,7 @@ def _extractFileName(url: str, headers: dict) -> str:
 
 async def parse(payload: dict) -> HttpTask:
     url: str = payload['url']
-    headers: dict = payload.get('headers', DEFAULT_HEADERS)
+    headers: dict = payload.get('headers') or DEFAULT_HEADERS
     proxies: dict = payload.get('proxies', getProxies())
     blockNum: int = payload.get('preBlockNum', cfg.preBlockNum.value)
     path: Path = payload.get('path', Path(cfg.downloadFolder.value))

--- a/features/m3u8_pack/task.py
+++ b/features/m3u8_pack/task.py
@@ -542,7 +542,7 @@ class M3U8Worker(Worker):
 
 async def parse(payload: dict) -> M3U8Task:
     url = str(payload["url"]).strip()
-    headers = payload.get("headers", DEFAULT_HEADERS)
+    headers = payload.get("headers") or DEFAULT_HEADERS
     proxies = payload.get("proxies", getProxies())
     path = Path(payload.get("path", cfg.downloadFolder.value))
     requestHeaders, requestCookies = splitRequestHeadersAndCookies(headers if isinstance(headers, dict) else DEFAULT_HEADERS)


### PR DESCRIPTION
## 描述 (Description)
此 PR 解决了单次下载后 User-Agent 恢复默认的问题，实现了全局 User-Agent 的自定义与持久化保存。

Closes #309 

## 主要更改 (Changes)
- **GUI 界面更新**: 在设置页的“综合下载设置”分组中，新增了 `User-Agent` 自定义输入框 (`UserAgentSettingCard`)。
- **配置持久化**: 在 `config.py` 中新增了 `customUserAgent` 配置项，用户的输入会自动保存到 Ghost Downloader 的本地 JSON 配置文件中。
- **核心逻辑适配**: 
  - 修改了 `browser_service.py`，通过浏览器扩展接管的下载任务能够正确读取并应用自定义的 User-Agent。
  - 更新了各下载引擎 (`http_pack`, `m3u8_pack`, `bittorrent_pack`) 的请求头部解析逻辑。现在网络请求会优先使用用户自定义的 User-Agent，如果用户留空，则无缝回退至原有的 `DEFAULT_HEADERS`。

## 测试说明 (Testing)
- [x] 在设置页修改 User-Agent 后重启程序，确认配置能够持久化保留。
- [x] 新建 HTTP/M3U8/BT 下载任务，抓包或打印测试确认请求头使用了自定义的 User-Agent。
- [x] 清空自定义 User-Agent 输入框，确认下载任务能正常回退使用默认的 User-Agent。
- [x] 验证浏览器扩展推送到桌面端的任务能正常携带正确的 User-Agent。

<img width="2719" height="1710" alt="image" src="https://github.com/user-attachments/assets/2ec83d0b-2cbe-4626-bee3-d746f75096f4" />
