### PR TITLE
让“关于”页面排列在设置页面的最下面

### DIFF
--- a/app/view/pages/setting_page.py
+++ b/app/view/pages/setting_page.py
@@ -313,6 +313,15 @@ class SettingPage(ScrollArea):
         self.vBoxLayout.addWidget(self.softwareGroup)
         self.vBoxLayout.addWidget(self.aboutGroup)
 
+    def addSettingGroup(self, groupWidget):
+        # 寻找“关于”分类在当前布局中的位置
+        index = self.vBoxLayout.indexOf(self.aboutGroup)
+        if index != -1:
+            # 把它插队到“关于”的前面
+            self.vBoxLayout.insertWidget(index, groupWidget)
+        else:
+            self.vBoxLayout.addWidget(groupWidget)
+
     def connectSignalToSlot(self):
         cfg.appRestartSig.connect(self._showRestartTooltip)
         cfg.browserExtensionPairToken.valueChanged.connect(lambda _: self._refreshBrowserPairTokenCard())

--- a/features/bili_pack/config.py
+++ b/features/bili_pack/config.py
@@ -829,7 +829,7 @@ class BilibiliConfig(PackConfig):
         self.parseBilibiliGroup.addSettingCard(self.parseDolbyCard)
         self.parseBilibiliGroup.addSettingCard(self.loginCard)
 
-        settingPage.vBoxLayout.addWidget(self.parseBilibiliGroup)
+        settingPage.addSettingGroup(self.parseBilibiliGroup)
 
 
 bilibiliConfig = BilibiliConfig()

--- a/features/bittorrent_pack/config.py
+++ b/features/bittorrent_pack/config.py
@@ -376,7 +376,7 @@ class BitTorrentConfig(PackConfig):
         ):
             self.bittorrentGroup.addSettingCard(card)
 
-        settingPage.vBoxLayout.addWidget(self.bittorrentGroup)
+        settingPage.addSettingGroup(self.bittorrentGroup)
 
 
 bittorrentConfig = BitTorrentConfig()

--- a/features/ffmpeg_pack/config.py
+++ b/features/ffmpeg_pack/config.py
@@ -183,7 +183,7 @@ class FFmpegConfig(PackConfig):
 
         self.ffmpegGroup.addSettingCard(self.installFolderCard)
         self.ffmpegGroup.addSettingCard(self.runtimeCard)
-        settingPage.vBoxLayout.addWidget(self.ffmpegGroup)
+        settingPage.addSettingGroup(self.ffmpegGroup)
 
         self.runtimeCard.refreshStatus()
 

--- a/features/github_pack/config.py
+++ b/features/github_pack/config.py
@@ -310,7 +310,7 @@ class GitHubConfig(PackConfig):
         self.githubGroup.addSettingCard(self.enableCard)
         self.githubGroup.addSettingCard(self.proxySiteCard)
 
-        settingPage.vBoxLayout.addWidget(self.githubGroup)
+        settingPage.addSettingGroup(self.githubGroup)
 
         self.enableCard.checkedChanged.connect(self._onEnabledChanged)
         self.viewAgreementButton.clicked.connect(self._showAgreement)

--- a/features/m3u8_pack/config.py
+++ b/features/m3u8_pack/config.py
@@ -324,7 +324,7 @@ class M3U8Config(PackConfig):
         ):
             self.m3u8Group.addSettingCard(card)
 
-        settingPage.vBoxLayout.addWidget(self.m3u8Group)
+        settingPage.addSettingGroup(self.m3u8Group)
         self.runtimeCard.refreshStatus()
 
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
- 其他，请描述内容： 让动态加载 Feature Pack 后“关于”分组保持在设置页面最底部

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

好的，这是一个适合作为 PR 介绍的简短文案：

---

**标题：** 优化设置页面布局：保持“关于”分组始终位于最底部

**描述：**

优化了设置页面（SettingPage）中配置分组的排列顺序。通过在 `SettingPage` 中引入并使用 `addSettingGroup` （向指定索引插入控件）的方法，确保了在动态加载各个 Feature Pack（如流媒体下载、Bilibili下载等）的设置项时，新加载的分组会正确插入到“关于”分组的上方。

<!-- 请添加任何你认为有帮助的信息 -->

**为什么需要这个改变？**
之前由于 Feature Pack 是在主页面初始化后动态追加挂载的（使用 `addWidget`），这会导致其设置卡组自动排在页面最末尾，从而把原本的“关于”分组顶到了中间，这样会导致找“关于”页面变得不符合直觉（我一直都认为关于应该排列在最下面）。

> 修改后“关于”分组位置
<img width="1919" height="1003" alt="image" src="https://github.com/user-attachments/assets/07d71b68-d6e0-46d0-b1cc-8e943845c727" />

> 修改前“关于”分组位置
<img width="1919" height="1002" alt="image" src="https://github.com/user-attachments/assets/fcff0a1b-9909-4897-a377-5ca84da0b7fc" />