### PR TITLE
修复 Linux Wayland 下每次窗口切回前台都弹出下载确认框的问题

### DIFF
--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -218,13 +218,23 @@ class MainWindow(MSFluentWindow):
 
         return urls
 
+    def _isWayland(self) -> bool:
+        return QApplication.platformName() == "wayland"
+
     def _onClipboardDataChanged(self):
         clipboard = QApplication.clipboard()
         mimeData = clipboard.mimeData()
         if mimeData.hasFormat(GD3_COPY_MIME_TYPE):
             return
 
-        urls = self._extractClipboardUrls(clipboard.text())
+        currentText = clipboard.text()
+
+        if self._isWayland():
+            if hasattr(self, '_lastClipboardText') and self._lastClipboardText == currentText:
+                return
+            self._lastClipboardText = currentText
+
+        urls = self._extractClipboardUrls(currentText)
         if not urls:
             return
 

--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -232,11 +232,13 @@ class MainWindow(MSFluentWindow):
         if self._isWayland():
             if hasattr(self, '_lastClipboardText') and self._lastClipboardText == currentText:
                 return
-            self._lastClipboardText = currentText
 
         urls = self._extractClipboardUrls(currentText)
         if not urls:
             return
+
+        if self._isWayland():
+            self._lastClipboardText = currentText
 
         bringWindowToTop(self)
         self.showAddTaskDialog(urls=urls)


### PR DESCRIPTION
<!-- To use the English pull request template, create your PR with `template=en.md`. -->
<!-- Example: https://github.com/XiaoYouChR/Ghost-Downloader-3/compare/main...your-branch?quick_pull=1&template=en.md -->

<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->
<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## PR 描述

修复 Linux Wayland 下每次窗口切回前台都弹出下载确认框的问题

**改动：**
- 通过 `QApplication.platformName()` 检测 Wayland 环境
- Wayland 下缓存上一次有效 URL 内容，相同则跳过处理
- 非 Wayland 平台行为不变

## Close #442 
<!-- 若存在相关 Issue,请在此处替换 xxx 为你要关闭的 Issue 编号 -->

## PR 类型
<!-- 请取消对应类型的注释 -->

Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单
<!-- 请检查你的 PR 是否满足以下要求 -->
<!-- 打勾适用于当前 PR 的内容 -->

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注
<!-- 请添加任何你认为有帮助的信息 -->
