### PR TITLE
fix(Settings): preserve settings labels width

### DIFF
--- a/app/view/components/setting_card_group.py
+++ b/app/view/components/setting_card_group.py
@@ -12,7 +12,7 @@ from PySide6.QtCore import (
     Signal,
 )
 from PySide6.QtGui import QColor, QPainter
-from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QHBoxLayout, QSizePolicy, QVBoxLayout, QWidget
 from qfluentwidgets import (
     FluentIcon,
     SettingCard,
@@ -127,6 +127,13 @@ class CollapsibleSettingCardGroup(QWidget):
     def addSettingCard(self, card: QWidget) -> None:
         self.cardLayout.addWidget(card)
         card.installEventFilter(self._cardPaintSuppressor)
+        for w in (card, *card.findChildren(SettingCard)):
+            if hasattr(w, "hBoxLayout") and hasattr(w, "vBoxLayout"):
+                w.hBoxLayout.setStretchFactor(w.vBoxLayout, 1)
+            for name in ("titleLabel", "contentLabel"):
+                if label := getattr(w, name, None):
+                    label.setMinimumWidth(0)
+                    label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         # ExpandSettingCard 内部有 HeaderSettingCard / ExpandBorderWidget /
         # GroupSeparator 各自画背景或分隔线，吞掉 QScrollArea 自己的 paintEvent 不够
         if isinstance(card, ExpandSettingCard):

--- a/app/view/pages/setting_page.py
+++ b/app/view/pages/setting_page.py
@@ -34,6 +34,7 @@ class SettingPage(ScrollArea):
         super().__init__(parent)
         self.container = QWidget()
         self.vBoxLayout = QVBoxLayout(self.container)
+        self.vBoxLayout.setContentsMargins(4, 0, 4, 0)
         # stretch 永远是 vBoxLayout 的最后一个 item，吸收多余高度让 group 顶部对齐
         self.vBoxLayout.addStretch(1)
         self.generalDownloadGroup = CollapsibleSettingCardGroup(self.tr("综合下载设置"), "general", self.container)


### PR DESCRIPTION
## PR 描述

`SettingCard` 的标题和描述 `QLabel` 会参与 `minimumSizeHint` 计算，长翻译会把设置页内部 `container` 撑宽

  ## PR 类型

  - Bug 修复

  ## PR 检查清单

  - [x] 应用成功启动且测试无 Bug
  - [x] 不包含破坏式更新

<img width="1559" height="856" alt="image_279" src="https://github.com/user-attachments/assets/9c64ff96-807a-4f24-bb13-134ec602feaf" />

<p align="center"><strong>演示</strong></p>