### PR TITLE
feat(update): 点击下载后自动下载更新包并支持更新包一键安装

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,17 @@ The durable stored form of a Task, one JSON line in `tasks.jsonl`.
 **Saved Tasks**:
 Task Records loaded from a previous app run that may need to start again.
 
+**Update Task**:
+A transient Task that downloads a release asset into the Update Folder for
+self-update. Class-level `transient = True`: never written to `tasks.jsonl`,
+never resumed, hidden from the task list, and outside the `maxTaskNum` limit.
+Only used for the Windows `.exe` full-update path; other assets fall back to an
+ordinary Task.
+
+**Update Folder**:
+The `APP_DATA_DIR/update` directory holding a downloaded installer. Wiped
+unconditionally on both app start and app stop — nothing persists across runs.
+
 **Coroutine Runner**:
 The app actor that owns the background asyncio loop and Qt callback delivery.
 Knows nothing about Task.

--- a/Ghost-Downloader-3.py
+++ b/Ghost-Downloader-3.py
@@ -76,6 +76,9 @@ def startApp(application, isSilent=False):
         setDockIconVisible(cfg.shouldShowDockIcon.value, activate=False)
     coroutineRunner.start()
 
+    from app.config.paths import clearUpdateDir
+    clearUpdateDir()  # 启动清理：清空上次残留的更新文件（含崩溃留下的半成品）
+
     MainWindow.refreshThemeColor()
     window = MainWindow()
 
@@ -205,6 +208,8 @@ def startApp(application, isSilent=False):
         aria2RpcServer.stop()
         featureService.stop()
         coroutineRunner.stop()
+        from app.config.paths import clearUpdateDir
+        clearUpdateDir()  # 退出清理：不保留任何更新文件，压缩损坏半成品残留窗口
 
     application.aboutToQuit.connect(stopApp)
 

--- a/app/config/paths.py
+++ b/app/config/paths.py
@@ -25,6 +25,18 @@ USER_PATH = Path(QStandardPaths.writableLocation(
     QStandardPaths.StandardLocation.GenericDataLocation
 )) / "GhostDownloader"
 
+UPDATE_DIR = Path(APP_DATA_DIR) / "update"
+
+
+def clearUpdateDir() -> None:
+    """无条件清空更新文件夹。启动与退出各调用一次，确保不残留损坏的半成品或旧安装包。"""
+    from loguru import logger
+    try:
+        if UPDATE_DIR.exists():
+            shutil.rmtree(UPDATE_DIR, ignore_errors=True)
+    except Exception as e:
+        logger.opt(exception=e).warning("清空更新文件夹失败 {}", UPDATE_DIR)
+
 def isPortable() -> bool:
     return APP_DATA_DIR == str(PORTABLE_PATH)
 

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -183,6 +183,7 @@ class Task:
     canEdit: ClassVar[bool] = False
     fileType: ClassVar[type] = TaskFile
     hasOutputFile: ClassVar[bool] = True
+    transient: ClassVar[bool] = False  # True: 临时任务，不持久化、不 resume、不进列表、不受 maxTaskNum 限制
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -126,11 +126,14 @@ class TaskService(QObject):
     tasksAllCompleted = Signal()
     fileDisappeared = Signal(object)
     diskSpaceInsufficient = Signal(int, int)
+    transientCompleted = Signal(object)
+    transientFailed = Signal(object, str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._store = TaskStore()
         self._queue = TaskQueue()
+        self._transient: dict[str, str] = {}  # taskId -> workId，进行中的临时任务
         self._fileWatcher = QFileSystemWatcher(self)
         self._watchedPaths: dict[str, str] = {}
         self._fileWatcher.fileChanged.connect(self._onWatchedFileChanged)
@@ -153,6 +156,9 @@ class TaskService(QObject):
         return self._queue.runningCount()
 
     def add(self, task: Task) -> None:
+        if task.transient:
+            self.addTransient(task)
+            return
         if task.taskId in self._store.tasks:
             return
         if cfg.isCategoryEnabled.value:
@@ -177,6 +183,37 @@ class TaskService(QObject):
             except OSError:
                 pass
         self._schedule(task)
+
+    def addTransient(self, task: Task) -> None:
+        """运行一个临时任务（如自更新下载）。不进 Store（故不持久化、不 resume）、
+        不进 Queue（故独立于 maxTaskNum 立即开始）、不发 taskAdded（故列表不渲染）。
+        通过 transientCompleted / transientFailed 回调进度结束状态；取消用 cancelTransient。"""
+        from app.models.task import TaskStatus
+        from app.services.coroutine_runner import coroutineRunner
+
+        task.setStatus(TaskStatus.RUNNING)
+        workId = coroutineRunner.submit(
+            task.run(),
+            done=lambda _: self._onTransientDone(task),
+            failed=lambda error: self._onTransientFailed(task, error),
+        )
+        self._transient[task.taskId] = workId
+
+    def _onTransientDone(self, task: Task) -> None:
+        self._transient.pop(task.taskId, None)
+        self.transientCompleted.emit(task)
+
+    def _onTransientFailed(self, task: Task, error: str) -> None:
+        self._transient.pop(task.taskId, None)
+        self.transientFailed.emit(task, error)
+
+    def cancelTransient(self, task: Task) -> None:
+        """取消一个仍在进行的临时任务并删除其半成品文件。"""
+        from app.services.coroutine_runner import coroutineRunner
+        workId = self._transient.pop(task.taskId, None)
+        if workId is not None:
+            coroutineRunner.cancel(workId)
+        task.deleteFiles()
 
     def start(self, task: Task) -> None:
         if self._queue.isRunning(task.taskId) or self._queue.isWaiting(task.taskId):
@@ -245,6 +282,10 @@ class TaskService(QObject):
 
     def stop(self) -> None:
         from app.models.task import TaskStatus
+        from app.services.coroutine_runner import coroutineRunner
+        for taskId, workId in list(self._transient.items()):
+            coroutineRunner.cancel(workId)
+        self._transient.clear()
         for task in self._store.tasks.values():
             if task.status in {TaskStatus.RUNNING, TaskStatus.WAITING}:
                 task.setStatus(TaskStatus.PAUSED)

--- a/app/services/update_service.py
+++ b/app/services/update_service.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QObject, QProcess, QTimer, Qt, Signal
+from PySide6.QtWidgets import QApplication
+from loguru import logger
+from qfluentwidgets import FluentIcon, InfoBar, InfoBarPosition, PushButton, StateToolTip
+
+from app.config.paths import UPDATE_DIR
+from app.format import toReadableSize
+
+if TYPE_CHECKING:
+    from PySide6.QtWidgets import QWidget
+    from app.update import ReleaseAsset
+
+
+def isFullUpdateAsset(asset: ReleaseAsset) -> bool:
+    """完整"下载→安装→退出"流程仅在 Windows 且资源为 .exe 时启用。"""
+    return sys.platform == "win32" and asset.name.lower().endswith(".exe")
+
+
+# 模块级单例：同一时刻只允许一个更新下载
+_activeController: UpdateDownloadController | None = None
+
+
+def startUpdateDownload(asset: ReleaseAsset, window: QWidget) -> None:
+    """自更新的公共入口。所有入口（新版本 InfoBar、未来的版本详情弹窗）都汇入这里。
+
+    - Windows + .exe：走完整流程（下载到 update 文件夹 → StateToolTip 进度
+      → 完成 InfoBar → 立即安装并退出）。
+    - 其余情况：回退为普通下载任务（进列表、留普通下载目录、不退出）。
+    """
+    global _activeController
+
+    if not isFullUpdateAsset(asset):
+        _fallbackDownload(asset, window)
+        return
+
+    # 单例防护：已有更新下载在进行。用 isValid 排除已被 Qt 销毁（如下载中关窗）的悬空引用。
+    from shiboken6 import isValid
+    if _activeController is not None and isValid(_activeController):
+        InfoBar.info(
+            window.tr("更新下载中"), window.tr("新版本正在下载，请稍候"),
+            duration=3000, position=InfoBarPosition.BOTTOM_RIGHT, parent=window,
+        )
+        return
+
+    _activeController = UpdateDownloadController(asset, window)
+    _activeController.finished.connect(_onControllerFinished)
+    _activeController.start()
+
+
+def _onControllerFinished() -> None:
+    global _activeController
+    _activeController = None
+
+
+def _fallbackDownload(asset: ReleaseAsset, window: QWidget) -> None:
+    """非 exe / 非 Windows：沿用普通任务下载逻辑（进列表、持久化、普通下载目录）。"""
+    from app.models.task import TaskOptions
+    from app.services.coroutine_runner import coroutineRunner
+    from app.services.feature_service import featureService
+    from app.services.task_service import taskService
+
+    def onParseFailed(error: str) -> None:
+        InfoBar.error(
+            window.tr("创建下载任务失败"), str(error),
+            duration=3000, position=InfoBarPosition.BOTTOM_RIGHT, parent=window,
+        )
+
+    coroutineRunner.submit(
+        featureService.parse(TaskOptions(url=asset.downloadUrl)),
+        done=taskService.add,
+        failed=onParseFailed,
+        owner=window,
+    )
+    InfoBar.info(
+        window.tr("开始下载更新"), window.tr("更新包将下载到默认下载目录，请下载完成后手动安装"),
+        duration=5000, position=InfoBarPosition.BOTTOM_RIGHT, parent=window,
+    )
+
+
+class UpdateDownloadController(QObject):
+    """驱动一次 Windows exe 的完整更新流程：下载 → 进度提示 → 安装并退出。"""
+
+    finished = Signal()  # 无论成功/失败/取消，结束时发出，用于释放单例
+
+    def __init__(self, asset: ReleaseAsset, window: QWidget):
+        super().__init__(window)
+        self._asset = asset
+        self._window = window
+        self._task = None
+        self._stateToolTip: StateToolTip | None = None
+        self._progressTimer = QTimer(self)
+        self._progressTimer.setInterval(1000)
+        self._progressTimer.timeout.connect(self._refreshProgress)
+
+    def start(self) -> None:
+        from app.config.paths import clearUpdateDir
+        from app.models.task import TaskOptions
+        from app.services.coroutine_runner import coroutineRunner
+        from features.http_pack.pack import buildHttpTask
+        from features.http_pack.task import UpdateTask
+
+        clearUpdateDir()  # 下载前清空，确保目录干净
+        UPDATE_DIR.mkdir(parents=True, exist_ok=True)
+
+        self._stateToolTip = StateToolTip(
+            self._window.tr("正在下载新版本"),
+            self._window.tr("准备中..."),
+            self._window,
+        )
+        self._stateToolTip.move(self._stateToolTip.getSuitablePos())
+        self._stateToolTip.show()
+
+        options = TaskOptions(url=self._asset.downloadUrl, outputFolder=UPDATE_DIR)
+        coroutineRunner.submit(
+            buildHttpTask(options, taskClass=UpdateTask),
+            done=self._onTaskBuilt,
+            failed=self._onDownloadFailed,
+            owner=self,
+        )
+
+    def _onTaskBuilt(self, task) -> None:
+        from app.services.task_service import taskService
+
+        self._task = task
+        taskService.transientCompleted.connect(self._onTransientCompleted)
+        taskService.transientFailed.connect(self._onTransientFailed)
+        taskService.addTransient(task)
+        self._progressTimer.start()
+
+    def _refreshProgress(self) -> None:
+        if self._task is None or self._stateToolTip is None:
+            return
+        progress, speed, receivedBytes = self._task.currentSnapshot()
+        fileSize = self._task.fileSize
+        if fileSize > 0:
+            self._stateToolTip.setContent(
+                self._window.tr("{0}% · {1}/{2} · {3}/s").format(
+                    int(progress),
+                    toReadableSize(receivedBytes),
+                    toReadableSize(fileSize),
+                    toReadableSize(speed),
+                )
+            )
+        else:
+            self._stateToolTip.setContent(
+                self._window.tr("{0} · {1}/s").format(
+                    toReadableSize(receivedBytes), toReadableSize(speed)
+                )
+            )
+
+    def _onTransientCompleted(self, task) -> None:
+        if task is not self._task:
+            return
+        self._disconnectService()
+        self._progressTimer.stop()
+        self._refreshProgress()
+        if self._stateToolTip is not None:
+            self._stateToolTip.setContent(self._window.tr("下载完成"))
+            self._stateToolTip.setState(True)
+            self._stateToolTip = None
+        self._promptInstall()
+        self.finished.emit()
+
+    def _onTransientFailed(self, task, error: str) -> None:
+        if task is not self._task:
+            return
+        self._disconnectService()
+        self._progressTimer.stop()
+        if self._stateToolTip is not None:
+            self._stateToolTip.setContent(self._window.tr("下载失败: {0}").format(error))
+            self._stateToolTip.setState(True)
+            self._stateToolTip = None
+        self.finished.emit()
+
+    def _onDownloadFailed(self, error: str) -> None:
+        """构造任务阶段（探测）失败。"""
+        self._progressTimer.stop()
+        if self._stateToolTip is not None:
+            self._stateToolTip.setContent(self._window.tr("下载失败: {0}").format(error))
+            self._stateToolTip.setState(True)
+            self._stateToolTip = None
+        self.finished.emit()
+
+    def _disconnectService(self) -> None:
+        from app.services.task_service import taskService
+        try:
+            taskService.transientCompleted.disconnect(self._onTransientCompleted)
+            taskService.transientFailed.disconnect(self._onTransientFailed)
+        except (RuntimeError, TypeError):
+            pass
+
+
+    def _promptInstall(self) -> None:
+        installerPath = Path(self._task.outputPath)
+        # 用显式 Horizontal 构造：InfoBar.success 便捷方法默认 Vertical，addWidget 按钮会溢出窗口
+        infoBar = InfoBar(
+            icon=FluentIcon.UPDATE,
+            title=self._window.tr("新版本已下载"),
+            content=self._window.tr("是否立即安装？安装程序将启动，本程序会随即退出。"),
+            orient=Qt.Orientation.Horizontal,
+            isClosable=True,
+            duration=-1,
+            position=InfoBarPosition.BOTTOM_RIGHT,
+            parent=self._window,
+        )
+        installButton = PushButton(FluentIcon.UPDATE, self._window.tr("立即安装"))
+        installButton.clicked.connect(lambda: self._installAndQuit(installerPath, infoBar))
+        infoBar.addWidget(installButton)
+        infoBar.show()
+
+    def _installAndQuit(self, installerPath: Path, infoBar) -> None:
+        if not installerPath.exists():
+            InfoBar.error(
+                self._window.tr("安装失败"), self._window.tr("找不到安装程序文件"),
+                duration=3000, position=InfoBarPosition.BOTTOM_RIGHT, parent=self._window,
+            )
+            return
+        started = QProcess.startDetached(str(installerPath))
+        if not started:
+            logger.error("启动安装程序失败 {}", installerPath)
+            InfoBar.error(
+                self._window.tr("安装失败"),
+                self._window.tr("无法启动安装程序，请手动运行"),
+                duration=5000, position=InfoBarPosition.BOTTOM_RIGHT, parent=self._window,
+            )
+            return
+        infoBar.close()
+        QApplication.quit()
+
+
+

--- a/app/view/pages/task_page.py
+++ b/app/view/pages/task_page.py
@@ -625,6 +625,8 @@ class TaskPage(QWidget):
         return featureService.taskCard(task, self.scrollWidget)
 
     def _onTaskAdded(self, task: Task) -> None:
+        if task.transient:  # 临时任务（如自更新下载）不在列表渲染
+            return
         if task.taskId in self._cards:
             return
         card = self._createCard(task)

--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -179,7 +179,7 @@ class MainWindow(MSFluentWindow):
             parent=self,
         )
         downloadButton = PrimaryPushButton(FluentIcon.DOWNLOAD, self.tr("立即下载"))
-        downloadButton.clicked.connect(lambda: self._onDownloadUpdateClicked(release))
+        downloadButton.clicked.connect(lambda: self._onDownloadUpdateClicked(release, infoBar))
         infoBar.addWidget(downloadButton)
         detailButton = PushButton(FluentIcon.CHAT, self.tr("查看详情"))
         detailButton.clicked.connect(lambda: ReleaseInfoDialog(release, self).exec())
@@ -189,11 +189,9 @@ class MainWindow(MSFluentWindow):
         infoBar.addWidget(sponsorButton)
         infoBar.show()
 
-    def _onDownloadUpdateClicked(self, release) -> None:
-        from app.models.task import TaskOptions
-        from app.services.coroutine_runner import coroutineRunner
-        from app.services.feature_service import featureService
+    def _onDownloadUpdateClicked(self, release, infoBar=None) -> None:
         from app.update import bestAsset
+        from app.services.update_service import startUpdateDownload
 
         asset = bestAsset(release)
         if asset is None:
@@ -206,12 +204,9 @@ class MainWindow(MSFluentWindow):
             ReleaseInfoDialog(release, self).exec()
             return
 
-        coroutineRunner.submit(
-            featureService.parse(TaskOptions(url=asset.downloadUrl)),
-            done=taskService.add,
-            failed=self._onUpdateAssetParseFailed,
-            owner=self,
-        )
+        if infoBar is not None:
+            infoBar.close()  # 点击下载后，新版本提示的使命完成，交接给 StateToolTip
+        startUpdateDownload(asset, self)
 
     def _onUpdateAssetParseFailed(self, error: str) -> None:
         InfoBar.error(

--- a/docs/adr/0004-self-update-transient-task.md
+++ b/docs/adr/0004-self-update-transient-task.md
@@ -1,0 +1,42 @@
+# Self-update reuses the task pipeline as a transient task
+
+The auto-update download reuses the existing HTTP download engine
+(`HttpTask` / `HttpTaskStep` via `TaskService`) instead of a standalone
+downloader. To keep it out of the user's task list and out of persistence, an
+`UpdateTask(HttpTask)` subclass carries a class-level `transient = True` flag.
+`TaskService.add`, the store's `flush`, `resumeSaved`, and the task page's
+`_onTaskAdded` all skip transient tasks: not written to `tasks.jsonl`, not
+resumed on next launch, not rendered as a card, and started immediately outside
+the `maxTaskNum` concurrency limit. The `UpdateTask` is constructed directly
+rather than via `featureService.parse`, because a pack decides which class
+`parse` returns and cannot yield a custom subclass.
+
+The full "download → ask → run installer → quit" flow is **Windows + `.exe`
+only**. Any other asset (`.msi`, `.zip`, macOS, Linux, or `bestAsset` returning
+None) falls back to the pre-existing behavior: an ordinary persisted Task in the
+normal download folder, visible in the list. So only the exe path uses the
+Update Folder and the StateToolTip; the fallback path is unchanged.
+
+Progress shows in a `StateToolTip`; on success a persistent InfoBar offers
+"install now", which launches the installer via `QProcess.startDetached` and
+then quits the app. The Update Folder is wiped on both start and stop, so an
+interrupted download never leaves a broken file lingering, and no downloaded
+installer survives across runs.
+
+## Considered Options
+
+- **Standalone lightweight downloader** (bypass `TaskService`, stream bytes
+  directly): rejected — the user wanted to reuse the battle-tested download
+  engine (chunking, rate limit, progress snapshots) rather than reimplement it.
+
+- **Instance-level hidden flag + a side set of update task IDs in TaskService**:
+  rejected — an instance field would either hit serialization or need a
+  parallel bookkeeping set. A `ClassVar` subclass keeps the flag out of
+  `tasks.jsonl` entirely (only `f.repr=True` dataclass fields are serialized),
+  which guarantees old `tasks.jsonl` files still load: `filterFields` drops
+  unknown keys and fills missing ones with defaults. Backward compatibility was
+  a hard requirement.
+
+- **Keep a completed installer across runs so the user can install later**:
+  rejected — it contradicts the unconditional start/stop cleanup and adds
+  conditional-deletion complexity. Not installing is treated as abandoning.

--- a/features/http_pack/pack.py
+++ b/features/http_pack/pack.py
@@ -44,162 +44,168 @@ class HttpParser(TaskParser):
         return any(path.endswith(ext) for ext in DOWNLOADABLE_EXTENSIONS)
 
     async def parse(self, options: TaskOptions) -> Task:
-        url = options.url
-        headers = dict(options.headers)
-        clientProfile = options.clientProfile
-        subworkerCount = options.subworkerCount
-        outputFolder = options.outputFolder
+        return await buildHttpTask(options)
 
-        name = ""
-        fileSize = SpecialFileSize.UNKNOWN
-        canUseRangeRequests = False
-        lastModified = ""
 
-        if isinstance(options, ResourceTaskOptions) and options.name:
-            name = toSafeFilename(options.name, fallback=f"file_{time_ns()}")
-            fileSize = options.size if options.size > 0 else SpecialFileSize.UNKNOWN
-            canUseRangeRequests = options.canUseRangeRequests
-        else:
-            emulation = toEmulation(
-                options.clientProfile or cfg.clientProfile.value,
-                options.sourceUserAgent,
-            )
-            client = buildClient(emulation=emulation)
+async def buildHttpTask(options: TaskOptions, taskClass: type[HttpTask] = HttpTask) -> HttpTask:
+    """探测 URL 并构造一个 HttpTask（或其子类，如 UpdateTask）。
+    parse 与自更新入口共用同一套探测/组装逻辑，仅 taskClass 不同。"""
+    url = options.url
+    headers = dict(options.headers)
+    clientProfile = options.clientProfile
+    subworkerCount = options.subworkerCount
+    outputFolder = options.outputFolder
 
-            def rangeTotal(h: dict) -> int:
-                cr = h.get("content-range", "")
-                if not cr or "/" not in cr:
-                    return SpecialFileSize.UNKNOWN
-                _, _, total = cr.rpartition("/")
-                if not total or total == "*":
-                    return SpecialFileSize.UNKNOWN
-                try:
-                    size = int(total)
-                except ValueError:
-                    return SpecialFileSize.UNKNOWN
-                return size if size > 0 else SpecialFileSize.UNKNOWN
+    name = ""
+    fileSize = SpecialFileSize.UNKNOWN
+    canUseRangeRequests = False
+    lastModified = ""
 
-            def bodyLength(h: dict) -> int:
-                val = h.get("content-length", "").strip()
-                if not val:
-                    return SpecialFileSize.UNKNOWN
-                try:
-                    length = int(val)
-                except ValueError:
-                    return SpecialFileSize.UNKNOWN
-                return length if length > 0 else SpecialFileSize.UNKNOWN
-
-            async def request(rangeValue: str = "") -> tuple[int, dict[str, str], str]:
-                probeHeaders = dict(headers)
-                probeHeaders["accept-encoding"] = "identity"
-                if rangeValue:
-                    probeHeaders["range"] = rangeValue
-                response = await client.get(url, headers=probeHeaders)
-                try:
-                    status = response.status.as_int()
-                    if status not in {200, 206, 416}:
-                        response.raise_for_status()
-                    return (
-                        status,
-                        {k.decode().lower(): v.decode() for k, v in response.headers},
-                        str(response.url),
-                    )
-                finally:
-                    response.close()
-
-            try:
-                statusCode, responseHeaders, finalUrl = await request("bytes=1-1")
-
-                fileSize = rangeTotal(responseHeaders)
-                canUseRangeRequests = statusCode == 206 and "content-range" in responseHeaders
-
-                if canUseRangeRequests:
-                    logger.info(
-                        "偏移 Range 探测成功, content-range: {}, fileSize: {}",
-                        responseHeaders.get("content-range", ""), fileSize,
-                    )
-                else:
-                    fileSize = bodyLength(responseHeaders)
-                    logger.info(
-                        "偏移 Range 探测返回 {}, content-length: {}",
-                        statusCode, responseHeaders.get("content-length", ""),
-                    )
-
-                    if statusCode == 200 and fileSize in {SpecialFileSize.UNKNOWN, 1}:
-                        fbStatus, fbHeaders, _ = await request("bytes=0-0")
-                        fbSize = rangeTotal(fbHeaders)
-                        if fbStatus == 206 and "content-range" in fbHeaders:
-                            logger.info(
-                                "回退 Range 探测成功, content-range: {}, fileSize: {}",
-                                fbHeaders.get("content-range", ""), fbSize,
-                            )
-                            fileSize = fbSize
-                            canUseRangeRequests = True
-                        else:
-                            if fileSize == SpecialFileSize.UNKNOWN:
-                                fileSize = bodyLength(fbHeaders)
-                                if fileSize == SpecialFileSize.UNKNOWN and fbStatus == 416:
-                                    fileSize = rangeTotal(fbHeaders)
-
-                cd = responseHeaders.get("content-disposition", "")
-                if cd:
-                    msg = Message()
-                    msg["Content-Disposition"] = cd
-                    params = msg.get_params(header="Content-Disposition")
-                    paramDict = {k.lower(): v for k, v in params}
-                    name = collapse_rfc2231_value(
-                        paramDict.get("filename") or paramDict.get("filename*") or ""
-                    ).strip("\"' ")
-
-                if not name and "content-location" in responseHeaders:
-                    cl = responseHeaders["content-location"]
-                    name = unquote(urlparse(cl).path.split("/")[-1])
-
-                if not name:
-                    queryParams = parse_qs(urlparse(finalUrl).query)
-                    rcd = queryParams.get("response-content-disposition", [""])[0]
-                    if "filename=" in rcd.lower():
-                        m = re.search(r'filename\s*=\s*["\']?([^"\';]+)["\']?', rcd, re.IGNORECASE)
-                        if m:
-                            name = unquote(m.group(1)).strip("\"' ")
-
-                if not name:
-                    path = urlparse(finalUrl).path
-                    if path and "/" in path:
-                        cleanPath = path.split(";")[0]
-                        name = unquote(cleanPath.split("/")[-1])
-
-                contentType = responseHeaders.get("content-type", "").split(";", 1)[0].lower().strip()
-                standardExt = guess_extension(contentType) if contentType else ""
-                standardExt = standardExt or ""
-
-                if not name:
-                    name = f"file_{time_ns()}{standardExt}"
-                elif "." not in name and standardExt:
-                    name = f"{name}{standardExt}"
-
-                name = toSafeFilename(name, fallback=f"file_{time_ns()}")
-                lastModified = responseHeaders.get("last-modified", "")
-            finally:
-                client.close()
-
-        task = HttpTask(
-            name=name,
-            url=url,
-            fileSize=fileSize,
-            outputFolder=outputFolder,
+    if isinstance(options, ResourceTaskOptions) and options.name:
+        name = toSafeFilename(options.name, fallback=f"file_{time_ns()}")
+        fileSize = options.size if options.size > 0 else SpecialFileSize.UNKNOWN
+        canUseRangeRequests = options.canUseRangeRequests
+    else:
+        emulation = toEmulation(
+            options.clientProfile or cfg.clientProfile.value,
+            options.sourceUserAgent,
         )
-        task.addStep(HttpTaskStep(
-            stepIndex=1,
-            url=url,
-            fileSize=fileSize,
-            headers=headers,
-            clientProfile=clientProfile,
-            subworkerCount=subworkerCount,
-            canUseRangeRequests=canUseRangeRequests,
-            lastModified=lastModified,
-        ))
-        return task
+        client = buildClient(emulation=emulation)
+
+        def rangeTotal(h: dict) -> int:
+            cr = h.get("content-range", "")
+            if not cr or "/" not in cr:
+                return SpecialFileSize.UNKNOWN
+            _, _, total = cr.rpartition("/")
+            if not total or total == "*":
+                return SpecialFileSize.UNKNOWN
+            try:
+                size = int(total)
+            except ValueError:
+                return SpecialFileSize.UNKNOWN
+            return size if size > 0 else SpecialFileSize.UNKNOWN
+
+        def bodyLength(h: dict) -> int:
+            val = h.get("content-length", "").strip()
+            if not val:
+                return SpecialFileSize.UNKNOWN
+            try:
+                length = int(val)
+            except ValueError:
+                return SpecialFileSize.UNKNOWN
+            return length if length > 0 else SpecialFileSize.UNKNOWN
+
+        async def request(rangeValue: str = "") -> tuple[int, dict[str, str], str]:
+            probeHeaders = dict(headers)
+            probeHeaders["accept-encoding"] = "identity"
+            if rangeValue:
+                probeHeaders["range"] = rangeValue
+            response = await client.get(url, headers=probeHeaders)
+            try:
+                status = response.status.as_int()
+                if status not in {200, 206, 416}:
+                    response.raise_for_status()
+                return (
+                    status,
+                    {k.decode().lower(): v.decode() for k, v in response.headers},
+                    str(response.url),
+                )
+            finally:
+                response.close()
+
+        try:
+            statusCode, responseHeaders, finalUrl = await request("bytes=1-1")
+
+            fileSize = rangeTotal(responseHeaders)
+            canUseRangeRequests = statusCode == 206 and "content-range" in responseHeaders
+
+            if canUseRangeRequests:
+                logger.info(
+                    "偏移 Range 探测成功, content-range: {}, fileSize: {}",
+                    responseHeaders.get("content-range", ""), fileSize,
+                )
+            else:
+                fileSize = bodyLength(responseHeaders)
+                logger.info(
+                    "偏移 Range 探测返回 {}, content-length: {}",
+                    statusCode, responseHeaders.get("content-length", ""),
+                )
+
+                if statusCode == 200 and fileSize in {SpecialFileSize.UNKNOWN, 1}:
+                    fbStatus, fbHeaders, _ = await request("bytes=0-0")
+                    fbSize = rangeTotal(fbHeaders)
+                    if fbStatus == 206 and "content-range" in fbHeaders:
+                        logger.info(
+                            "回退 Range 探测成功, content-range: {}, fileSize: {}",
+                            fbHeaders.get("content-range", ""), fbSize,
+                        )
+                        fileSize = fbSize
+                        canUseRangeRequests = True
+                    else:
+                        if fileSize == SpecialFileSize.UNKNOWN:
+                            fileSize = bodyLength(fbHeaders)
+                            if fileSize == SpecialFileSize.UNKNOWN and fbStatus == 416:
+                                fileSize = rangeTotal(fbHeaders)
+
+            cd = responseHeaders.get("content-disposition", "")
+            if cd:
+                msg = Message()
+                msg["Content-Disposition"] = cd
+                params = msg.get_params(header="Content-Disposition")
+                paramDict = {k.lower(): v for k, v in params}
+                name = collapse_rfc2231_value(
+                    paramDict.get("filename") or paramDict.get("filename*") or ""
+                ).strip("\"' ")
+
+            if not name and "content-location" in responseHeaders:
+                cl = responseHeaders["content-location"]
+                name = unquote(urlparse(cl).path.split("/")[-1])
+
+            if not name:
+                queryParams = parse_qs(urlparse(finalUrl).query)
+                rcd = queryParams.get("response-content-disposition", [""])[0]
+                if "filename=" in rcd.lower():
+                    m = re.search(r'filename\s*=\s*["\']?([^"\';]+)["\']?', rcd, re.IGNORECASE)
+                    if m:
+                        name = unquote(m.group(1)).strip("\"' ")
+
+            if not name:
+                path = urlparse(finalUrl).path
+                if path and "/" in path:
+                    cleanPath = path.split(";")[0]
+                    name = unquote(cleanPath.split("/")[-1])
+
+            contentType = responseHeaders.get("content-type", "").split(";", 1)[0].lower().strip()
+            standardExt = guess_extension(contentType) if contentType else ""
+            standardExt = standardExt or ""
+
+            if not name:
+                name = f"file_{time_ns()}{standardExt}"
+            elif "." not in name and standardExt:
+                name = f"{name}{standardExt}"
+
+            name = toSafeFilename(name, fallback=f"file_{time_ns()}")
+            lastModified = responseHeaders.get("last-modified", "")
+        finally:
+            client.close()
+
+    task = taskClass(
+        name=name,
+        url=url,
+        fileSize=fileSize,
+        outputFolder=outputFolder,
+    )
+    task.addStep(HttpTaskStep(
+        stepIndex=1,
+        url=url,
+        fileSize=fileSize,
+        headers=headers,
+        clientProfile=clientProfile,
+        subworkerCount=subworkerCount,
+        canUseRangeRequests=canUseRangeRequests,
+        lastModified=lastModified,
+    ))
+    return task
 
 
 class HttpPack(FeaturePack):

--- a/features/http_pack/task.py
+++ b/features/http_pack/task.py
@@ -51,6 +51,15 @@ class HttpTask(Task):
         )
 
 
+@dataclass(kw_only=True, eq=False)
+class UpdateTask(HttpTask):
+    """自更新专用任务：复用 HTTP 下载引擎，但作为临时任务存在。
+    transient=True → 不写入 tasks.jsonl、不参与 resumeSaved、不在列表渲染、不受 maxTaskNum 限制。
+    canEdit=False → 不允许用户编辑。"""
+    transient = True
+    canEdit = False
+
+
 @dataclass(kw_only=True)
 class HttpTaskStep(TaskStep):
     url: str = ""


### PR DESCRIPTION
## PR 描述

点击"立即下载"更新后，不再作为普通下载任务，而是自动下载更新包并支持一键安装：

- **Windows 且资源为 `.exe`**：下载到 `APP_DATA_DIR/update` 文件夹，用 StateToolTip 实时显示下载进度（位置与其他提示一致），完成后弹出 InfoBar 询问是否立即安装；点击"立即安装"后启动安装程序并随即退出自身。
- **其余情况（`.msi`/`.zip`/非 Windows）**：沿用现有普通任务下载逻辑（进列表、留默认下载目录、不退出）。
- 更新任务复用 HTTP 下载引擎，但作为临时任务存在（`transient` ClassVar）：不写入 `tasks.jsonl`、不参与 `resumeSaved`、不在任务列表渲染、独立于 `maxTaskNum` 立即开始。
- `update` 文件夹在应用启动与退出时各无条件清空一次，不残留损坏的半成品或旧安装包。
- 提供公共入口 `startUpdateDownload(asset, window)`，未来版本详情弹窗大改后可一行接入手动选择下载。

## PR 类型

- 功能

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

（`transient` 为 ClassVar 不进序列化，`filterFields` 会丢弃未知键、缺失键用默认值填充，旧版 `tasks.jsonl` 可正常读取，已通过冒烟测试验证向下兼容。）

## 备注

新增架构决策记录 `docs/adr/0004-self-update-transient-task.md`，并在 `CONTEXT.md` 补充 Update Task / Update Folder 术语。
