### PR TITLE
feat: 新增下载进度条样式选项（分段/经典）

### DIFF
--- a/app/config/cfg.py
+++ b/app/config/cfg.py
@@ -50,6 +50,11 @@ class CloseMode(Enum):
     QUIT = "Quit"
 
 
+class ProgressBarStyle(Enum):
+    SEGMENTED = "Segmented"
+    CLASSIC = "Classic"
+
+
 class ProxyValidator(ConfigValidator):
     PATTERN = compile(
         r"^"
@@ -232,6 +237,10 @@ class Config(QConfig):
     language = OptionsConfigItem(
         "Personalization", "Language", Language.AUTO,
         OptionsValidator(Language), LanguageSerializer(), restart=True,
+    )
+    progressBarStyle = OptionsConfigItem(
+        "Personalization", "ProgressBarStyle", ProgressBarStyle.SEGMENTED,
+        OptionsValidator(ProgressBarStyle), EnumSerializer(ProgressBarStyle),
     )
 
     # 软件

--- a/app/view/pages/setting_page.py
+++ b/app/view/pages/setting_page.py
@@ -271,6 +271,12 @@ class SettingPage(ScrollArea):
                                        "English (US)", "日本語 (日本)", "Русский (Россия)",
                                        "Português (Brasil)", self.tr("使用系统设置")]),
         )
+        personalCards.append(
+            ComboBoxSettingCard(cfg.progressBarStyle, FluentIcon.TILES,
+                                self.tr("下载进度条样式"),
+                                self.tr("多线程 HTTP 下载时的进度条外观，其他任务始终为经典样式"),
+                                texts=[self.tr("分段"), self.tr("经典")]),
+        )
         self.personalGroup.addSettingCards(personalCards)
 
         self.autoRunCard = SwitchSettingCard(

--- a/features/http_pack/cards.py
+++ b/features/http_pack/cards.py
@@ -3,6 +3,7 @@ from PySide6.QtGui import QColor, QPainter, QPaintEvent
 from PySide6.QtWidgets import QWidget
 from qfluentwidgets import isDarkTheme, themeColor
 
+from app.config.cfg import cfg, ProgressBarStyle
 from app.view.cards.task_cards import UniversalTaskCard
 from .task import HttpTaskStep
 
@@ -97,6 +98,19 @@ class SegmentedProgressBar(QWidget):
 class HttpTaskCard(UniversalTaskCard):
     def _buildProgressBar(self) -> QWidget:
         step = self.task.steps[0] if self.task.steps else None
-        if isinstance(step, HttpTaskStep) and step.canUseRangeRequests and step.subworkerCount > 1:
+        if (cfg.progressBarStyle.value == ProgressBarStyle.SEGMENTED
+                and isinstance(step, HttpTaskStep)
+                and step.canUseRangeRequests and step.subworkerCount > 1):
             return SegmentedProgressBar(step, self)
         return super()._buildProgressBar()
+
+    def _bind(self) -> None:
+        super()._bind()
+        cfg.progressBarStyle.valueChanged.connect(self._onProgressBarStyleChanged)
+
+    def _onProgressBarStyleChanged(self) -> None:
+        self.progressBar.deleteLater()
+        self.progressBar = self._buildProgressBar()
+        self.progressBar.setGeometry(4, self.height() - 4, self.width() - 8, 4)
+        self.progressBar.show()
+        self.refresh(force=True)


### PR DESCRIPTION
## PR 描述

在「个性化」设置中新增「**下载进度条样式**」选项，可在**分段**与**经典**两种样式间切换，默认为**分段**。

- **分段**：多线程 HTTP 下载时，按各线程的字节范围分段绘制进度（即原有 `SegmentedProgressBar`）。
- **经典**：统一显示整体进度的单色进度条（qfluentwidgets `ProgressBar`）。
- 不支持多线程分片的任务类型（BT、m3u8、单线程 HTTP 等）无论选择哪种样式，均自动降级为经典样式，行为与修改前完全一致。
- 切换设置后**立即生效，无需重启**：`HttpTaskCard` 订阅配置变更并就地重建进度条。

实现要点：

- `app/config/cfg.py`：新增 `ProgressBarStyle` 枚举与 `progressBarStyle` 配置项（`Personalization` 段，默认 `Segmented`）。
- `app/view/pages/setting_page.py`：个性化分组新增一张 `ComboBoxSettingCard`；移动端设置页继承复用，无需额外改动。
- `features/http_pack/cards.py`：仅在「分段」样式下且任务满足多线程分片条件时才使用 `SegmentedProgressBar`，其余场景走基类经典进度条；订阅 `cfg.progressBarStyle.valueChanged` 实现即时切换。

自动降级为零成本：`SegmentedProgressBar` 本就只在 `HttpTaskCard._buildProgressBar` 这一处产生，其他任务类型经由基类返回经典进度条，天然不受新设置影响。

## PR 类型

- 功能

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

## 备注

默认值为「分段」，保持原有观感与行为；未改动其他任务类型的进度条渲染路径，不含破坏式更新。
