### PR TITLE
feat(Android): add first-launch language selection

### DIFF
--- a/android/main.py
+++ b/android/main.py
@@ -73,6 +73,8 @@ def startApp(application):
         from app.view.mobile.language_dialog import MobileLanguageDialog
 
         languageDialog = MobileLanguageDialog()
+        setupTouchScrolling(languageDialog)
+        languageDialog.showMaximized()
         languageDialog.exec()
         cfg.set(cfg.language, languageDialog.selectedLanguage())
         cfg.set(cfg.hasSelectedAndroidLanguage, True)

--- a/android/main.py
+++ b/android/main.py
@@ -52,7 +52,10 @@ def startApp(application):
     from app.services.browser_service import browserService
     from app.services.speed_meter import speedMeter
     from app.signal_bus import signalBus
-    from app.startup import loadEngine, loadPacks, startEngine, bindNotifications, checkUpdateAtStartup, stopEngine
+    from app.startup import (
+        bindNotifications, checkUpdateAtStartup, loadEngine, loadPacks,
+        loadTranslation, startEngine, stopEngine,
+    )
     from app.view.mobile.device import setupTouchScrolling
     from app.view.mobile.window import MobileMainWindow
 
@@ -65,6 +68,17 @@ def startApp(application):
 
     loadEngine(application)
     loadPacks()
+
+    if not cfg.hasSelectedAndroidLanguage.value:
+        from app.view.mobile.language_dialog import MobileLanguageDialog
+
+        languageDialog = MobileLanguageDialog()
+        languageDialog.exec()
+        cfg.set(cfg.language, languageDialog.selectedLanguage())
+        cfg.set(cfg.hasSelectedAndroidLanguage, True)
+        loadTranslation(application)
+        languageDialog.deleteLater()
+        application.processEvents()
 
     mainWindow = MobileMainWindow()
     mainWindow.show()

--- a/app/config/cfg.py
+++ b/app/config/cfg.py
@@ -283,6 +283,9 @@ class Config(QConfig):
 
     # OOBE
     hasCompletedOobe = ConfigItem("Software", "HasCompletedOobe", False, BoolValidator())
+    hasSelectedAndroidLanguage = ConfigItem(
+        "Software", "HasSelectedAndroidLanguage", False, BoolValidator()
+    )
 
     # UI 状态
     expandedSettingGroups = ConfigItem("UI", "ExpandedSettingGroups", [], StringListValidator())

--- a/app/startup.py
+++ b/app/startup.py
@@ -2,18 +2,27 @@
 from __future__ import annotations
 
 
-def loadEngine(application) -> None:
+def loadTranslation(application) -> None:
     from PySide6.QtCore import QTranslator
     from app.config.cfg import cfg
-    from app.services.coroutine_runner import coroutineRunner
 
     import app.assets.resources  # noqa: F401
+
+    previous = getattr(application, "_gd3Translator", None)
+    if previous is not None:
+        application.removeTranslator(previous)
 
     locale = cfg.language.value.value
     translator = QTranslator(application)
     translator.load(locale, "gd3", ".", ":/i18n")
     application.installTranslator(translator)
+    application._gd3Translator = translator
 
+
+def loadEngine(application) -> None:
+    from app.services.coroutine_runner import coroutineRunner
+
+    loadTranslation(application)
     coroutineRunner.start()
 
 

--- a/app/view/mobile/language_dialog.py
+++ b/app/view/mobile/language_dialog.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QLocale, Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout
+from qfluentwidgets import BodyLabel, ComboBox, PrimaryPushButton, SubtitleLabel
+
+from app.config.cfg import LANGUAGE_TEXTS, Language, cfg
+
+
+def preferredLanguage(locale: QLocale | None = None) -> Language:
+    """Choose a supported language for an Android locale, defaulting to English."""
+    locale = locale or QLocale.system()
+    supported = [language for language in cfg.language.options if language != Language.AUTO]
+
+    if locale.territory() == QLocale.Country.HongKong:
+        return Language.CANTONESE
+
+    for language in supported:
+        candidate = language.value
+        if (
+            candidate.language() == locale.language()
+            and candidate.territory() == locale.territory()
+        ):
+            return language
+
+    for language in supported:
+        if language.value.language() == locale.language():
+            return language
+
+    return Language.ENGLISH_UNITED_STATES
+
+
+class MobileLanguageDialog(QDialog):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._languages = [
+            language for language in cfg.language.options if language != Language.AUTO
+        ]
+
+        self.titleLabel = SubtitleLabel("Choose your language / 选择语言", self)
+        self.descriptionLabel = BodyLabel(
+            "Select the language used by Ghost Downloader.\n"
+            "请选择 Ghost Downloader 的界面语言。",
+            self,
+        )
+        self.languageCombo = ComboBox(self)
+        self.continueButton = PrimaryPushButton("Continue / 继续", self)
+
+        self._initWidget()
+        self._initLayout()
+        self.continueButton.clicked.connect(self.accept)
+
+    def _initWidget(self) -> None:
+        self.setWindowTitle("Ghost Downloader")
+        self.setModal(True)
+        self.setMinimumWidth(300)
+        self.descriptionLabel.setWordWrap(True)
+
+        for language in self._languages:
+            self.languageCombo.addItem(LANGUAGE_TEXTS[language])
+
+        selected = (
+            cfg.language.value
+            if cfg.language.value != Language.AUTO
+            else preferredLanguage()
+        )
+        self.languageCombo.setCurrentIndex(self._languages.index(selected))
+
+    def _initLayout(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(16)
+        layout.addWidget(self.titleLabel)
+        layout.addWidget(self.descriptionLabel)
+        layout.addSpacing(8)
+        layout.addWidget(self.languageCombo)
+        layout.addStretch(1)
+        layout.addWidget(
+            self.continueButton,
+            0,
+            Qt.AlignmentFlag.AlignRight,
+        )
+
+    def selectedLanguage(self) -> Language:
+        index = self.languageCombo.currentIndex()
+        if 0 <= index < len(self._languages):
+            return self._languages[index]
+        return Language.ENGLISH_UNITED_STATES

--- a/app/view/mobile/language_dialog.py
+++ b/app/view/mobile/language_dialog.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QLocale, Qt
-from PySide6.QtWidgets import QDialog, QVBoxLayout
-from qfluentwidgets import BodyLabel, ComboBox, PrimaryPushButton, SubtitleLabel
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import (
+    QButtonGroup, QDialog, QFrame, QHBoxLayout, QScrollArea, QVBoxLayout,
+    QWidget,
+)
+from qfluentwidgets import (
+    BodyLabel, CardWidget, FluentIcon, IconWidget, PrimaryPushButton,
+    RadioButton, TitleLabel, isDarkTheme, qconfig,
+)
 
 from app.config.cfg import LANGUAGE_TEXTS, Language, cfg
 
@@ -30,6 +37,22 @@ def preferredLanguage(locale: QLocale | None = None) -> Language:
     return Language.ENGLISH_UNITED_STATES
 
 
+class LanguageCard(CardWidget):
+
+    def __init__(self, text: str, parent=None):
+        super().__init__(parent)
+        self.radioButton = RadioButton(text, self)
+        self.setClickEnabled(True)
+        self.setFixedHeight(56)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(16, 0, 16, 0)
+        layout.addWidget(self.radioButton, 1)
+
+        self.clicked.connect(lambda: self.radioButton.setChecked(True))
+
+
 class MobileLanguageDialog(QDialog):
 
     def __init__(self, parent=None):
@@ -38,14 +61,20 @@ class MobileLanguageDialog(QDialog):
             language for language in cfg.language.options if language != Language.AUTO
         ]
 
-        self.titleLabel = SubtitleLabel("Choose your language / 选择语言", self)
+        self.iconWidget = IconWidget(FluentIcon.LANGUAGE, self)
+        self.titleLabel = TitleLabel("Choose your language", self)
         self.descriptionLabel = BodyLabel(
-            "Select the language used by Ghost Downloader.\n"
-            "请选择 Ghost Downloader 的界面语言。",
+            "Select the language used by Ghost Downloader. You can change it "
+            "later in Settings.",
             self,
         )
-        self.languageCombo = ComboBox(self)
-        self.continueButton = PrimaryPushButton("Continue / 继续", self)
+        self.scrollArea = QScrollArea(self)
+        self.scrollWidget = QWidget(self.scrollArea)
+        self.languageLayout = QVBoxLayout(self.scrollWidget)
+        self.languageGroup = QButtonGroup(self)
+        self.continueButton = PrimaryPushButton("Continue", self)
+        self.contentWidget = QWidget(self)
+        self.contentLayout = QVBoxLayout(self.contentWidget)
 
         self._initWidget()
         self._initLayout()
@@ -54,36 +83,73 @@ class MobileLanguageDialog(QDialog):
     def _initWidget(self) -> None:
         self.setWindowTitle("Ghost Downloader")
         self.setModal(True)
-        self.setMinimumWidth(300)
+        self.setWindowFlag(Qt.WindowType.FramelessWindowHint)
+        self.setWindowState(self.windowState() | Qt.WindowState.WindowMaximized)
+        self.contentWidget.setMaximumWidth(560)
+        self.iconWidget.setFixedSize(42, 42)
         self.descriptionLabel.setWordWrap(True)
-
-        for language in self._languages:
-            self.languageCombo.addItem(LANGUAGE_TEXTS[language])
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollArea.setWidget(self.scrollWidget)
+        self.scrollArea.setFrameShape(QFrame.Shape.NoFrame)
+        self.scrollArea.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.scrollArea.setStyleSheet(
+            "QScrollArea { border: none; background: transparent; }"
+            "QScrollArea > QWidget > QWidget { background: transparent; }"
+        )
+        self.scrollWidget.setObjectName("languageScrollWidget")
+        self.scrollWidget.setStyleSheet(
+            "QWidget#languageScrollWidget { background: transparent; }"
+        )
+        self.continueButton.setMinimumHeight(48)
 
         selected = (
             cfg.language.value
             if cfg.language.value != Language.AUTO
             else preferredLanguage()
         )
-        self.languageCombo.setCurrentIndex(self._languages.index(selected))
+
+        for index, language in enumerate(self._languages):
+            card = LanguageCard(LANGUAGE_TEXTS[language], self.scrollWidget)
+            self.languageGroup.addButton(card.radioButton, index)
+            self.languageLayout.addWidget(card)
+            if language == selected:
+                card.radioButton.setChecked(True)
+
+        qconfig.themeChanged.connect(self.update)
 
     def _initLayout(self) -> None:
+        self.languageLayout.setContentsMargins(4, 4, 4, 4)
+        self.languageLayout.setSpacing(4)
+        self.languageLayout.addStretch(1)
+
+        self.contentLayout.setContentsMargins(24, 36, 24, 24)
+        self.contentLayout.setSpacing(14)
+        self.contentLayout.addWidget(self.iconWidget)
+        self.contentLayout.addSpacing(6)
+        self.contentLayout.addWidget(self.titleLabel)
+        self.contentLayout.addWidget(self.descriptionLabel)
+        self.contentLayout.addSpacing(10)
+        self.contentLayout.addWidget(self.scrollArea, 1)
+        self.contentLayout.addSpacing(10)
+        self.contentLayout.addWidget(self.continueButton)
+
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(24, 24, 24, 24)
-        layout.setSpacing(16)
-        layout.addWidget(self.titleLabel)
-        layout.addWidget(self.descriptionLabel)
-        layout.addSpacing(8)
-        layout.addWidget(self.languageCombo)
-        layout.addStretch(1)
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(
-            self.continueButton,
-            0,
-            Qt.AlignmentFlag.AlignRight,
+            self.contentWidget,
+            1,
+            Qt.AlignmentFlag.AlignHCenter,
         )
 
     def selectedLanguage(self) -> Language:
-        index = self.languageCombo.currentIndex()
+        index = self.languageGroup.checkedId()
         if 0 <= index < len(self._languages):
             return self._languages[index]
         return Language.ENGLISH_UNITED_STATES
+
+    def paintEvent(self, event) -> None:
+        painter = QPainter(self)
+        color = QColor(32, 32, 32) if isDarkTheme() else QColor(243, 243, 243)
+        painter.fillRect(self.rect(), color)

--- a/app/view/mobile/language_dialog.py
+++ b/app/view/mobile/language_dialog.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
 )
 from qfluentwidgets import (
     BodyLabel, CardWidget, FluentIcon, IconWidget, PrimaryPushButton,
-    RadioButton, TitleLabel, isDarkTheme, qconfig,
+    RadioButton, SubtitleLabel, isDarkTheme, qconfig,
 )
 
 from app.config.cfg import LANGUAGE_TEXTS, Language, cfg
@@ -62,7 +62,7 @@ class MobileLanguageDialog(QDialog):
         ]
 
         self.iconWidget = IconWidget(FluentIcon.LANGUAGE, self)
-        self.titleLabel = TitleLabel("Choose your language", self)
+        self.titleLabel = SubtitleLabel("Choose your language", self)
         self.descriptionLabel = BodyLabel(
             "Select the language used by Ghost Downloader. You can change it "
             "later in Settings.",
@@ -86,12 +86,20 @@ class MobileLanguageDialog(QDialog):
         self.setWindowFlag(Qt.WindowType.FramelessWindowHint)
         self.setWindowState(self.windowState() | Qt.WindowState.WindowMaximized)
         self.contentWidget.setMaximumWidth(560)
+        self.contentWidget.setMinimumWidth(0)
         self.iconWidget.setFixedSize(42, 42)
+        self.titleLabel.setMinimumWidth(0)
+        self.titleLabel.setWordWrap(True)
+        self.descriptionLabel.setMinimumWidth(0)
         self.descriptionLabel.setWordWrap(True)
+        self.scrollArea.setMinimumWidth(0)
         self.scrollArea.setWidgetResizable(True)
         self.scrollArea.setWidget(self.scrollWidget)
         self.scrollArea.setFrameShape(QFrame.Shape.NoFrame)
         self.scrollArea.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.scrollArea.setVerticalScrollBarPolicy(
             Qt.ScrollBarPolicy.ScrollBarAlwaysOff
         )
         self.scrollArea.setStyleSheet(

--- a/tests/test_mobile_language_dialog.py
+++ b/tests/test_mobile_language_dialog.py
@@ -1,0 +1,23 @@
+import pytest
+from PySide6.QtCore import QLocale
+
+from app.config.cfg import Language
+from app.view.mobile.language_dialog import preferredLanguage
+
+
+@pytest.mark.parametrize(
+    ("locale_name", "expected"),
+    [
+        ("en_US", Language.ENGLISH_UNITED_STATES),
+        ("en_GB", Language.ENGLISH_UNITED_STATES),
+        ("zh_CN", Language.CHINESE_SIMPLIFIED),
+        ("zh_TW", Language.CHINESE_TRADITIONAL),
+        ("zh_HK", Language.CANTONESE),
+        ("ja_JP", Language.JAPANESE),
+        ("ru_RU", Language.RUSSIAN),
+        ("pt_PT", Language.PORTUGUESE_BRAZIL),
+        ("fr_FR", Language.ENGLISH_UNITED_STATES),
+    ],
+)
+def test_preferred_android_language(locale_name, expected):
+    assert preferredLanguage(QLocale(locale_name)) == expected


### PR DESCRIPTION
## Summary
- add an Android-only language chooser on first launch
- present the chooser as a maximized, frameless mobile page instead of a floating dialog
- replace the combo popup with large, touch-friendly language cards in a kinetic scrolling area
- make the page responsive down to 320×568 logical pixels in light and dark themes
- preselect supported device locales and fall back to English for unsupported locales
- reload the translator before constructing the mobile main window
- add locale-selection coverage for English, Chinese, Cantonese, Japanese, Russian, Portuguese, and fallback behavior

Closes #605

## Validation
- `python -m compileall` for all changed Python files
- `git diff --check`
- `bash -n android/run_build.sh android/build_apk.sh` under WSL 2
- Android debug APK built successfully with the repository Docker/p4a pipeline (70.6 MB)
- off-screen Qt visual QA at 360×780 and 320×568 in light and dark themes
- verified the small-phone language list retains a working 163-pixel scroll range with its visual scrollbar hidden

## Notes
- Full pytest execution was not available locally because the host Python environment does not include PySide6.