### PR TITLE
fix(YouTube): 修复 CC 字幕下载实际上不工作的问题

### DIFF
--- a/features/yt_dlp_pack/cards.py
+++ b/features/yt_dlp_pack/cards.py
@@ -14,8 +14,7 @@ from app.models.task import TaskStatus
 from app.view.cards.draft_cards import DraftCard
 from app.view.cards.task_cards import MultiFileTaskCard, FieldSpec, SPEED_FIELD, ETA_FIELD
 from app.view.components.tree_view import AutoSizingTreeView
-from .config import ytDlpConfig
-from .task import STEPS_PER_VIDEO, YouTubeTask
+from .task import AUTO_SUBTITLE_PREFIX, STEPS_PER_VIDEO, YouTubeTask
 
 
 def buildQualityTiers(mediaInfo: dict) -> list[tuple[str, str]]:
@@ -50,19 +49,15 @@ def buildQualityTiers(mediaInfo: dict) -> list[tuple[str, str]]:
     return result
 
 
-def buildSubtitleChoices(mediaInfo: dict) -> list[tuple[str, str, bool]]:
-    choices: list[tuple[str, str, bool]] = []
-    seen: set[str] = set()
+def buildSubtitleChoices(mediaInfo: dict) -> list[tuple[str, str]]:
+    choices: list[tuple[str, str]] = []
+    for language, formats in (mediaInfo.get("subtitles") or {}).items():
+        if any(f.get("ext") == "json3" and f.get("url") for f in formats):
+            choices.append((language, language))
 
-    for lang in (mediaInfo.get("subtitles") or {}):
-        if lang not in seen:
-            seen.add(lang)
-            choices.append((lang, lang, False))
-
-    for lang in (mediaInfo.get("automatic_captions") or {}):
-        if lang not in seen:
-            seen.add(lang)
-            choices.append((lang, f"{lang} (自动)", True))
+    for language, formats in (mediaInfo.get("automatic_captions") or {}).items():
+        if any(f.get("ext") == "json3" and f.get("url") for f in formats):
+            choices.append((f"{AUTO_SUBTITLE_PREFIX}{language}", f"{language} (自动)"))
 
     return choices
 
@@ -108,7 +103,7 @@ def toYtDlpNameText(task: YouTubeTask, speed: int, received: int) -> str | None:
 
 class SubtitleSelectDialog(MessageBoxBase):
 
-    def __init__(self, choices: list[tuple[str, str, bool]], parent=None):
+    def __init__(self, choices: list[tuple[str, str]], selected: list[str], parent=None):
         super().__init__(parent)
         self._choices = choices
 
@@ -121,12 +116,12 @@ class SubtitleSelectDialog(MessageBoxBase):
         self.treeView = AutoSizingTreeView(self, minimumVisibleRows=3, maximumVisibleRows=16)
         self.treeModel = QStandardItemModel(self.treeView)
 
-        self._initWidget()
+        self._initWidget(set(selected))
         self._initLayout()
         self._bind()
         self._refreshSummary()
 
-    def _initWidget(self) -> None:
+    def _initWidget(self, selected: set[str]) -> None:
         self.widget.setMinimumWidth(400)
         self.yesButton.setText(self.tr("确定"))
         self.cancelButton.setText(self.tr("取消"))
@@ -138,14 +133,11 @@ class SubtitleSelectDialog(MessageBoxBase):
 
         self.treeView.setModel(self.treeModel)
 
-        defaultLangs = {s.strip() for s in ytDlpConfig.subtitleLanguages.value.split(",") if s.strip()}
-
-        for langCode, label, _isAuto in self._choices:
+        for track, label in self._choices:
             item = QStandardItem(label)
             item.setCheckable(True)
-            item.setCheckState(Qt.CheckState.Checked if langCode in defaultLangs else Qt.CheckState.Unchecked)
-            item.setData(langCode, Qt.ItemDataRole.UserRole)
-            item.setData(_isAuto, Qt.ItemDataRole.UserRole + 1)
+            item.setCheckState(Qt.CheckState.Checked if track in selected else Qt.CheckState.Unchecked)
+            item.setData(track, Qt.ItemDataRole.UserRole)
             self.treeModel.appendRow(item)
 
     def _initLayout(self) -> None:
@@ -180,16 +172,12 @@ class SubtitleSelectDialog(MessageBoxBase):
         )
         self.summaryLabel.setText(self.tr("{0}/{1} 种语言").format(count, self.treeModel.rowCount()))
 
-    def selectedLanguages(self) -> tuple[str, bool]:
-        langs: list[str] = []
-        hasAuto = False
-        for row in range(self.treeModel.rowCount()):
-            item = self.treeModel.item(row, 0)
-            if item.checkState() == Qt.CheckState.Checked:
-                langs.append(item.data(Qt.ItemDataRole.UserRole))
-                if item.data(Qt.ItemDataRole.UserRole + 1):
-                    hasAuto = True
-        return ",".join(langs), hasAuto
+    def buildSelection(self) -> list[str]:
+        return [
+            self.treeModel.item(row, 0).data(Qt.ItemDataRole.UserRole)
+            for row in range(self.treeModel.rowCount())
+            if self.treeModel.item(row, 0).checkState() == Qt.CheckState.Checked
+        ]
 
 
 class VideoSelectDialog(MessageBoxBase):
@@ -393,11 +381,10 @@ class YtDlpDraftCard(DraftCard):
             self._task.videoFormatFilter = self._qualityTiers[index][0]
 
     def _onSubtitleClicked(self) -> None:
-        dialog = SubtitleSelectDialog(self._subtitleChoices, self.window())
+        task: YouTubeTask = self._task
+        dialog = SubtitleSelectDialog(self._subtitleChoices, task.subtitleTracks, self.window())
         if dialog.exec():
-            langs, includeAuto = dialog.selectedLanguages()
-            self._task.subtitleLanguages = langs
-            self._task.shouldIncludeAutoSubs = includeAuto
+            task.subtitleTracks = dialog.buildSelection()
 
     def _onVideoSelectClicked(self) -> None:
         task: YouTubeTask = self._task

--- a/features/yt_dlp_pack/config.py
+++ b/features/yt_dlp_pack/config.py
@@ -58,7 +58,6 @@ def clearCookies() -> None:
 
 class YtDlpConfig(PackConfig):
     installFolder = ConfigItem("YtDlp", "InstallFolder", f"{APP_DATA_DIR}/YtDlp", FolderValidator())
-    subtitleLanguages = ConfigItem("YtDlp", "SubtitleLanguages", "en")
     shouldPreferMp4 = ConfigItem("YtDlp", "PreferMp4", True, BoolValidator())
     shouldEmbedMetadata = ConfigItem("YtDlp", "EmbedMetadata", True, BoolValidator())
     shouldEmbedChapters = ConfigItem("YtDlp", "EmbedChapters", True, BoolValidator())

--- a/features/yt_dlp_pack/task.py
+++ b/features/yt_dlp_pack/task.py
@@ -31,6 +31,7 @@ ERROR_HINTS = (
 )
 
 STEPS_PER_VIDEO = 4
+AUTO_SUBTITLE_PREFIX = "auto:"
 
 _pathLock = threading.Lock()
 _pathInserted = False
@@ -96,6 +97,28 @@ def probePlaylist(url: str) -> list[dict]:
     ]
 
 
+def toSrt(payload: dict) -> str:
+    def toSrtTime(milliseconds: int) -> str:
+        hours, remainder = divmod(milliseconds // 1000, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d},{milliseconds % 1000:03d}"
+
+    lines: list[str] = []
+    for event in payload.get("events") or []:
+        text = "".join(segment.get("utf8", "") for segment in event.get("segs") or []).strip()
+        if not text:
+            continue
+        start = int(event.get("tStartMs") or 0)
+        end = start + int(event.get("dDurationMs") or 0)
+        lines.extend([
+            str(len(lines) // 4 + 1),
+            f"{toSrtTime(start)} --> {toSrtTime(end)}",
+            text,
+            "",
+        ])
+    return "\n".join(lines)
+
+
 @dataclass(kw_only=True)
 class YouTubeFile(TaskFile):
     videoId: str = ""
@@ -108,7 +131,7 @@ def buildStepGroup(fileIndex: int, videoUrl: str = "", videoStem: str = "") -> l
         YouTubeExtractStep(stepIndex=base + 1, fileIndex=fileIndex, videoUrl=videoUrl),
         YouTubeResourceStep(stepIndex=base + 2, fileIndex=fileIndex, videoStem=videoStem, role="video"),
         YouTubeResourceStep(stepIndex=base + 3, fileIndex=fileIndex, videoStem=videoStem, role="audio"),
-        YouTubeMergeStep(stepIndex=base + 4, fileIndex=fileIndex, videoStem=videoStem),
+        YouTubeMergeStep(stepIndex=base + 4, fileIndex=fileIndex, videoUrl=videoUrl, videoStem=videoStem),
     ]
 
 
@@ -118,8 +141,7 @@ class YouTubeTask(Task):
     canEdit = True
     fileType = YouTubeFile
     videoFormatFilter: str = ""
-    subtitleLanguages: str = ""
-    shouldIncludeAutoSubs: bool = False
+    subtitleTracks: list[str] = field(default_factory=list)
     isPlaylist: bool = False
 
     def setVideos(self, videos: list[dict]) -> None:
@@ -356,10 +378,12 @@ class YouTubeResourceStep(FFmpegResourceStep):
 @dataclass(kw_only=True)
 class YouTubeMergeStep(FFmpegStep):
     fileIndex: int = 0
+    videoUrl: str = ""
     videoStem: str = ""
     metadataTitle: str = ""
     metadataArtist: str = ""
     chapters: list[dict] = field(default_factory=list)
+    subtitleFilenames: list[str] = field(default_factory=list)
 
     @property
     def outputFile(self) -> str:
@@ -379,7 +403,24 @@ class YouTubeMergeStep(FFmpegStep):
         suffix = f".{self.audioExtension}" if self.audioExtension else ""
         return self.task.outputFolder / f"{stem}.audio{suffix}"
 
+    def deleteFiles(self) -> None:
+        for filename in self.subtitleFilenames:
+            (self.task.outputFolder / filename).unlink(missing_ok=True)
+
+    def moveFiles(self, oldFolder: Path, newFolder: Path) -> None:
+        super().moveFiles(oldFolder, newFolder)
+        for filename in self.subtitleFilenames:
+            subtitleFile = oldFolder / filename
+            targetFile = newFolder / filename
+            targetFile.parent.mkdir(parents=True, exist_ok=True)
+            if subtitleFile.exists():
+                shutil.move(str(subtitleFile), str(targetFile))
+
     async def run(self, reportSpeed, waitForSpeedLimit) -> None:
+        try:
+            await self._createSubtitleFiles()
+        except Exception:
+            logger.opt(exception=True).debug("Subtitle download failed")
         hasVideo = self._videoPath.exists()
         hasAudio = self._audioPath.exists()
 
@@ -397,6 +438,48 @@ class YouTubeMergeStep(FFmpegStep):
             shutil.move(str(singleInput), str(outputPath))
             Path(f"{singleInput}.ghd").unlink(missing_ok=True)
         self.setStatus(TaskStatus.COMPLETED)
+
+    async def _createSubtitleFiles(self) -> None:
+        if not self.task.subtitleTracks:
+            return
+
+        from app.client import buildClient
+        from app.platform.filesystem import toSafeFilename
+
+        info = await asyncio.to_thread(probeFormats, self.videoUrl or self.task.url)
+        outputFile = Path(self.outputFile)
+        outputFile.parent.mkdir(parents=True, exist_ok=True)
+        client = buildClient()
+        try:
+            for track in self.task.subtitleTracks:
+                try:
+                    isAutomatic = track.startswith(AUTO_SUBTITLE_PREFIX)
+                    language = track.removeprefix(AUTO_SUBTITLE_PREFIX) if isAutomatic else track
+                    source = "automatic_captions" if isAutomatic else "subtitles"
+                    formats = (info.get(source) or {}).get(language) or []
+                    subtitle = next(
+                        (f for f in formats if f.get("ext") == "json3" and f.get("url")),
+                        None,
+                    )
+                    if not subtitle:
+                        continue
+                    response = await client.get(subtitle["url"])
+                    response.raise_for_status()
+                    text = toSrt(await response.json())
+                    if not text:
+                        continue
+                    language = toSafeFilename(language, fallback="subtitle")
+                    autoSuffix = ".auto" if isAutomatic else ""
+                    subtitleFile = outputFile.with_name(
+                        f"{outputFile.stem}.{language}{autoSuffix}.srt"
+                    )
+                    subtitleFile.write_text(text, encoding="utf-8")
+                    if subtitleFile.name not in self.subtitleFilenames:
+                        self.subtitleFilenames.append(subtitleFile.name)
+                except Exception:
+                    logger.opt(exception=True).debug("Subtitle download failed: {}", track)
+        finally:
+            client.close()
 
     async def _runWithMetadata(self) -> None:
         from ffmpeg_pack.config import ffmpegRuntime


### PR DESCRIPTION
## PR 描述

修复 YouTube 下载参数页面可以选择 CC 字幕、但任务实际不会保存字幕的问题。

- 人工字幕和自动字幕可独立选择，同一语言可同时下载，并支持多语言选择
- 在媒体合并前重新解析当前视频的字幕地址，避免长时间下载、恢复或重试后使用过期链接
- 字幕保存到视频旁：`视频名.语言.srt`、`视频名.语言.auto.srt`
- 仅记录并移动、删除任务实际生成的字幕文件；字幕失败不影响视频任务完成，取消仍正常传播

## PR 类型

- Bug 修复

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

## 备注

- 基于最新 `main`（`e68afea`）完全重新实现并收敛为 1 个提交
- 仓库原有测试：`193 passed`；35 条既有 `RuntimeWarning` 与最新 `main` 基线一致
- PR 不包含 `tests/`、文档或配置文件新增
- 仅修改 3 个 YouTube 生产文件，未增加第三方依赖