### PR TITLE
fix(OOBE): 修复OOBE修改主题不会同步主题背景

### DIFF
--- a/app/view/windows/oobe_window.py
+++ b/app/view/windows/oobe_window.py
@@ -14,8 +14,9 @@ from qfluentwidgets import (
     GroupHeaderCardWidget, HorizontalPipsPager, IconWidget, InfoBar,
     InfoBarIcon, InfoBarPosition, PipsScrollButtonDisplayMode,
     PrimaryPushButton, PushButton, SubtitleLabel, SwitchButton, Theme,
-    TitleLabel, TransparentPushButton, isDarkTheme, themeColor,
+    TitleLabel, TransparentPushButton, isDarkTheme, qconfig, themeColor,
 )
+from qfluentwidgets.common.style_sheet import updateStyleSheet
 
 from app.config.cfg import cfg, LANGUAGE_TEXTS
 from app.config.constants import (
@@ -356,6 +357,8 @@ class BasicSettingsPage(QWidget):
 
     def _onThemePicked(self, theme: Theme) -> None:
         cfg.set(cfg.themeMode, theme)
+        updateStyleSheet()
+        qconfig.themeChangedFinished.emit()
         self._refreshThemeCards()
 
     def _refreshThemeCards(self) -> None:


### PR DESCRIPTION
<!-- To use the English pull request template, create your PR with `template=en.md`. -->
<!-- Example: https://github.com/XiaoYouChR/Ghost-Downloader-3/compare/main...your-branch?quick_pull=1&template=en.md -->

<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->
<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## PR 描述
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->
修复首次启动引导（OOBE）选择浅色、深色或跟随系统时，主题配置已经改变但当前窗口背景和控件样式未立即刷新的问题。

在现有主题选择入口中补齐 Fluent 控件样式刷新和窗口背景刷新信号，同时保持主题选择持久化。改动仅涉及 OOBE 窗口文件。

## Close 
#588
<!-- 若存在相关 Issue,请在此处替换 xxx 为你要关闭的 Issue 编号 -->

## PR 类型
<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单
<!-- 请检查你的 PR 是否满足以下要求 -->
<!-- 打勾适用于当前 PR 的内容 -->

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注
<!-- 请添加任何你认为有帮助的信息 -->

- 完整测试：`uv run --with pytest python -m pytest -q`，结果为 `187 passed`。
- 额外执行离屏 OOBE 主题交互检查，确认活动主题、背景刷新信号、卡片选中状态和持久化配置均同步更新。
- 未新增依赖、抽象、配置或测试文件。