### PR TITLE
refactor(task): 删除 sync 参数，pendingSteps 不再改变原数据

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -128,7 +128,7 @@ class TaskStep:
     def task(self) -> Task:
         return self._task
 
-    def setStatus(self, status: TaskStatus, sync: bool = True):
+    def _applyStatus(self, status: TaskStatus):
         self.status = status
         if status == TaskStatus.COMPLETED:
             self.progress = 100
@@ -140,23 +140,27 @@ class TaskStep:
         elif status == TaskStatus.FAILED:
             self.speed = 0
 
-        if sync and hasattr(self, "_task"):
+    def setStatus(self, status: TaskStatus):
+        self._applyStatus(status)
+        if hasattr(self, "_task"):
             self._task.updateStatus()
 
     def setError(self, error: StepError) -> None:
         self.error = error
-        self.status = TaskStatus.FAILED
-        self.speed = 0
+        self._applyStatus(TaskStatus.FAILED)
         if hasattr(self, "_task"):
             self._task.updateStatus()
 
-    def reset(self, sync: bool = True):
+    def _applyReset(self):
         self.status = TaskStatus.WAITING
         self.progress = 0
         self.receivedBytes = 0
         self.speed = 0
         self.error = None
-        if sync and hasattr(self, "_task"):
+
+    def reset(self):
+        self._applyReset()
+        if hasattr(self, "_task"):
             self._task.updateStatus()
 
     def setOptions(self, options: dict) -> None:
@@ -354,8 +358,8 @@ class Task:
             if step.status == TaskStatus.COMPLETED:
                 continue
             if status == TaskStatus.RUNNING and step.status == TaskStatus.FAILED:
-                step.reset(sync=False)
-            step.setStatus(status, sync=False)
+                step._applyReset()
+            step._applyStatus(status)
         return self.updateStatus()
 
     def reset(self) -> TaskStatus:
@@ -364,7 +368,7 @@ class Task:
             self.status = TaskStatus.WAITING
             return self.status
         for step in self.steps:
-            step.reset(sync=False)
+            step._applyReset()
         return self.updateStatus()
 
     def addStep(self, step: TaskStep):
@@ -386,8 +390,7 @@ class Task:
         self.updateStatus()
 
     def pendingSteps(self) -> Iterable[TaskStep]:
-        self.steps.sort(key=lambda step: step.stepIndex)
-        for step in self.steps:
+        for step in sorted(self.steps, key=lambda step: step.stepIndex):
             if self.status != TaskStatus.RUNNING:
                 break
             if not self._isStepSelected(step):

--- a/features/bittorrent_pack/task.py
+++ b/features/bittorrent_pack/task.py
@@ -92,7 +92,7 @@ class BTTask(Task):
         self.fileSize = sum(f.size for f in self.files if f.selected)
         # 完成后补选新文件：步骤打回 WAITING，等待重新调度补下
         if self.step.status == TaskStatus.COMPLETED and any(f.selected and not f.completed for f in self.files):
-            self.step.setStatus(TaskStatus.WAITING, sync=False)
+            self.step._applyStatus(TaskStatus.WAITING)
             self.updateStatus()
 
     def deleteFiles(self):

--- a/features/ftp_pack/task.py
+++ b/features/ftp_pack/task.py
@@ -141,10 +141,10 @@ class FtpStep(TaskStep):
         if "subworkerCount" in options:
             self.subworkerCount = options["subworkerCount"]
 
-    def setStatus(self, status: TaskStatus, sync: bool = True):
+    def setStatus(self, status: TaskStatus):
         if status == TaskStatus.COMPLETED:
             self.receivedBytes = self.fileSize
-        super().setStatus(status, sync=sync)
+        super().setStatus(status)
 
     @classmethod
     def fromFile(cls, file: TaskFile, task: Task) -> FtpStep:

--- a/features/m3u8_pack/task.py
+++ b/features/m3u8_pack/task.py
@@ -43,7 +43,7 @@ class M3U8Task(Task):
             for step in self.steps:
                 if isinstance(step, M3U8TaskStep) and step.status != TaskStatus.COMPLETED:
                     step._findOutputFile()
-                    step.setStatus(TaskStatus.COMPLETED, sync=False)
+                    step._applyStatus(TaskStatus.COMPLETED)
             self.updateStatus()
 
     def _move(self, newFolder: Path) -> None:


### PR DESCRIPTION
## Summary
- TaskStep.setStatus/reset 删除 `sync` 参数——总是触发 updateStatus()
- 批量操作（Task.setStatus, Task.reset）改用 `_applyStatus`/`_applyReset` 直接写字段，最后一次性调 updateStatus()
- `pendingSteps()` 从 `self.steps.sort()` 改为 `sorted()`，查询不再有副作用
- 更新 BT/M3U8/FTP pack 中所有 `sync=False` 调用点

## Test plan
- [ ] 验证多步骤任务（Bilibili, YouTube）的 step 状态推导正确
- [ ] 验证 BT 补选文件后 step 回退到 WAITING
- [ ] 验证 M3U8 直播任务加载时 status 校正正确