### PR TITLE
fix(UI): 恢复 SettingPage 搜索栏

### DIFF
--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -147,12 +147,12 @@ class MainWindow(MSFluentWindow):
 
     def _onSearchTextChanged(self, text: str) -> None:
         page = self.stackedWidget.currentWidget()
-        if isinstance(page, TaskPage):
+        if hasattr(page, 'setSearchText'):
             page.setSearchText(text)
 
     def _updateSearchTarget(self, page: QWidget) -> None:
         self.searchEdit.clear()
-        if isinstance(page, TaskPage):
+        if hasattr(page, 'setSearchText'):
             self.searchEdit.setPlaceholderText(page.searchPlaceholder)
             self.searchEdit.show()
         else:


### PR DESCRIPTION
## Summary
- DI 重构 (15d0c5c) 时 `_onSearchTextChanged` 和 `_updateSearchTarget` 的判断从 `hasattr(page, 'setSearchText')` 误改为 `isinstance(page, TaskPage)`
- SettingPage 实现了 `setSearchText`/`searchPlaceholder`，但因硬编码 TaskPage 导致搜索栏不再显示
- 改回 duck typing

## Test plan
- [ ] 打开桌面端，切换到设置页，确认搜索栏可见且可搜索
- [ ] 切换到任务页，确认搜索栏仍正常工作
- [ ] 切换到无搜索功能的 Pack 页面，确认搜索栏隐藏