### PR TITLE
feat: 添加可切换的下载进度条样式

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,11 @@ FeaturePack 可探测或提供安装任务的外部可执行文件家族。
 **Clipboard Listener**:
 剪贴板监听器。监控剪贴板变化，过滤出 URL 后发出通知。
 
+**Download Progress Bar Style**:
+An app-wide Settings choice for rendering Task progress. **Segmented** shows
+the byte ranges of eligible multi-subworker HTTP transfers; **Classic** shows
+one overall progress fill and is the fallback for every other Task.
+
 **Category**:
 下载分类和目标目录规则。将文件扩展名匹配到分类并解析下载目录。
 _Avoid_: group、tag、type

--- a/app/config/cfg.py
+++ b/app/config/cfg.py
@@ -62,6 +62,11 @@ class CloseMode(Enum):
     QUIT = "Quit"
 
 
+class ProgressBarStyle(Enum):
+    SEGMENTED = "Segmented"
+    CLASSIC = "Classic"
+
+
 class ProxyValidator(ConfigValidator):
     PATTERN = compile(
         r"^"
@@ -252,6 +257,10 @@ class Config(QConfig):
     aria2RpcEmulateFingerprint = ConfigItem("Aria2Rpc", "EmulateFingerprint", False, BoolValidator())
 
     # 个性化
+    downloadProgressBarStyle = OptionsConfigItem(
+        "Personalization", "DownloadProgressBarStyle", ProgressBarStyle.SEGMENTED,
+        OptionsValidator(ProgressBarStyle), EnumSerializer(ProgressBarStyle),
+    )
     if sys.platform == "win32":
         from app.platform.windows import isWin10
         backgroundEffect = OptionsConfigItem(

--- a/app/view/pages/setting_page.py
+++ b/app/view/pages/setting_page.py
@@ -237,6 +237,13 @@ class SettingPage(ScrollArea):
             ComboBoxSettingCard(cfg.themeMode, FluentIcon.BRUSH, self.tr("应用主题"),
                                 self.tr("更改应用程序的外观"),
                                 texts=[self.tr("浅色"), self.tr("深色"), self.tr("跟随系统设置")]),
+            ComboBoxSettingCard(
+                cfg.downloadProgressBarStyle,
+                FluentIcon.SPEED_HIGH,
+                self.tr("下载进度条样式"),
+                self.tr("设置多线程 HTTP 下载的进度条显示方式"),
+                texts=[self.tr("分段"), self.tr("经典")],
+            ),
         ]
         if sys.platform == "win32":
             personalCards.append(

--- a/features/http_pack/cards.py
+++ b/features/http_pack/cards.py
@@ -3,6 +3,7 @@ from PySide6.QtGui import QColor, QPainter, QPaintEvent
 from PySide6.QtWidgets import QWidget
 from qfluentwidgets import isDarkTheme, themeColor
 
+from app.config.cfg import ProgressBarStyle, cfg
 from app.view.cards.task_cards import TaskCard
 from .task import HttpTaskStep
 
@@ -92,8 +93,41 @@ class SegmentedProgressBar(QWidget):
 
 
 class HttpTaskCard(TaskCard):
-    def _createProgressBar(self) -> QWidget:
+    def _bind(self) -> None:
+        super()._bind()
+        cfg.downloadProgressBarStyle.valueChanged.connect(
+            self._onProgressBarStyleChanged
+        )
+
+    def _segmentedProgressStep(self) -> HttpTaskStep | None:
         step = self.task.steps[0] if self.task.steps else None
-        if isinstance(step, HttpTaskStep) and step.canUseRangeRequests and step.fileSize > 0 and step.subworkerCount > 1:
+        if (
+            isinstance(step, HttpTaskStep)
+            and step.canUseRangeRequests
+            and step.fileSize > 0
+            and step.subworkerCount > 1
+        ):
+            return step
+        return None
+
+    def _createProgressBar(self) -> QWidget:
+        step = self._segmentedProgressStep()
+        if (
+            cfg.downloadProgressBarStyle.value is ProgressBarStyle.SEGMENTED
+            and step is not None
+        ):
             return SegmentedProgressBar(step, self)
         return super()._createProgressBar()
+
+    def _onProgressBarStyleChanged(self, _: ProgressBarStyle) -> None:
+        if self._segmentedProgressStep() is None:
+            return
+
+        oldBar = self.progressBar
+        geometry = oldBar.geometry()
+        oldBar.hide()
+        self.progressBar = self._createProgressBar()
+        self.progressBar.setGeometry(geometry)
+        self.progressBar.show()
+        oldBar.deleteLater()
+        self.refresh(force=True)


### PR DESCRIPTION
<!-- To use the English pull request template, create your PR with `template=en.md`. -->
<!-- Example: https://github.com/XiaoYouChR/Ghost-Downloader-3/compare/main...your-branch?quick_pull=1&template=en.md -->

<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->
<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## PR 描述

在“个性化”设置中新增“下载进度条样式”，支持在“分段”和“经典”之间切换，默认为“分段”。

- 分段：沿用原有 `SegmentedProgressBar`，仅用于支持 Range、文件大小已知且配置多线程的 HTTP 下载。
- 经典：使用现有整体单色进度条。
- FTP、BT、m3u8、单线程或不支持 Range 的 HTTP 等任务保持原有进度条行为。
- 设置切换后立即作用于当前显示的符合条件的 HTTP 任务卡，无需重启，也不会改变任务或下载线程状态。

<!-- ## Close #xxx -->
<!-- 若存在相关 Issue,请在此处替换 xxx 为你要关闭的 Issue 编号 -->

## PR 类型

- 功能

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

## 备注

- 已基于最新上游 `main` 重放，PR 仅包含一个功能提交。
- 使用仓库现有测试套件验证：`193 passed`。
- 手动验证“分段 → 经典 → 分段”即时切换，任务状态保持不变。