### PR TITLE
fix(Bilibili): 修复切换下载类型后的文件名状态不同步

### DIFF
--- a/app/view/cards/draft_cards.py
+++ b/app/view/cards/draft_cards.py
@@ -78,6 +78,7 @@ class DraftCard(QWidget):
 
     def _onNameEditRequested(self) -> None:
         self.nameLabel.hide()
+        self.nameEdit.setText(self._task.name)
         self.nameEdit.show()
         self.nameEdit.setFocus()
         self.nameEdit.selectAll()

--- a/features/bili_pack/cards.py
+++ b/features/bili_pack/cards.py
@@ -239,6 +239,7 @@ class BilibiliDraftCard(MultiFileDraftCard):
         task: BilibiliTask = self._task
         task.setMode(DownloadMode(index))
         self._refreshSummary()
+        self._refreshButtonVisibility()
 
     def _onSelectFilesClicked(self) -> None:
         task: BilibiliTask = self._task
@@ -258,7 +259,6 @@ class BilibiliDraftCard(MultiFileDraftCard):
     def _refreshSummary(self) -> None:
         self.sizeLabel.setText(toReadableSize(self._task.fileSize))
         self.nameLabel.setText(self._task.name)
-        self._refreshButtonVisibility()
 
     def _buildSubtitleChoices(self) -> list[tuple[str, str]]:
         seen: set[str] = set()

--- a/features/bili_pack/task.py
+++ b/features/bili_pack/task.py
@@ -60,6 +60,7 @@ class BilibiliTask(Task):
         return self.outputFolder
 
     def setMode(self, mode: DownloadMode) -> None:
+        self._baseName = Path(self.name).stem
         self.mode = mode
         self._rebuildSteps()
 


### PR DESCRIPTION
## PR 描述

修复 Bilibili 下载类型与任务文件名状态不同步的问题：

- 从视频切换为音频后，双击文件名时编辑框使用当前 `.m4a` Task Name，不再回退为旧 `.mp4`。
- 用户手动改名后再切换下载类型时，保留自定义主文件名，仅按 Video、Audio、Cover 更新扩展名。
- 将 Bilibili 按钮可见性刷新限定在初始化完成和 Download Mode 变化时，避免构造期访问尚未创建的控件。

## PR 类型

- Bug 修复

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

## 备注

- `python -m pytest -q`：205 passed。
- Bilibili DraftCard UI smoke：Video → Audio → 双击文件名 → Enter，Task Name 与输出路径均保持 `.m4a`。
- 无关联 Issue。