### PR TITLE
feat(Aria2Rpc): implement aria2.tellStatus + fix parse-failure callback TypeError (#645)

### DIFF
--- a/app/services/aria2_rpc.py
+++ b/app/services/aria2_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from secrets import token_hex
@@ -12,6 +13,7 @@ from loguru import logger
 
 from app.config.cfg import cfg
 from app.config.constants import VERSION
+from app.models.task import TaskStatus
 
 if TYPE_CHECKING:
     from app.models.task import Task
@@ -19,6 +21,21 @@ if TYPE_CHECKING:
 JSONRPC_PARSE_ERROR = -32700
 JSONRPC_INVALID_REQUEST = -32600
 JSONRPC_METHOD_NOT_FOUND = -32601
+
+_TASK_STATUS_TO_ARIA2 = {
+    TaskStatus.WAITING: "waiting",
+    TaskStatus.RUNNING: "active",
+    TaskStatus.PAUSED: "paused",
+    TaskStatus.COMPLETED: "complete",
+    TaskStatus.FAILED: "error",
+}
+
+
+@dataclass
+class _GidRecord:
+    # task 与 error 均为空表示仍在解析
+    task: Task | None = None
+    error: str = ""
 
 
 class Aria2RpcServer(QObject):
@@ -31,6 +48,7 @@ class Aria2RpcServer(QObject):
         self._addTask = addTask
         self._server = QTcpServer(self)
         self._buffers: dict[int, bytes] = {}
+        self._gidRecords: dict[str, _GidRecord] = {}
 
         self._server.newConnection.connect(self._onNewConnection)
 
@@ -143,6 +161,8 @@ class Aria2RpcServer(QObject):
 
         if method == "aria2.addUri":
             self._addUri(socket, rpcId, params)
+        elif method == "aria2.tellStatus":
+            self._tellStatus(socket, rpcId, params)
         elif method == "aria2.getVersion":
             self._respond(socket, rpcId, {"version": VERSION, "enabledFeatures": ["HTTPS"]})
         else:
@@ -179,6 +199,7 @@ class Aria2RpcServer(QObject):
 
         gid = token_hex(8)
         self._respond(socket, rpcId, gid)
+        self._gidRecords[gid] = _GidRecord()
 
         from app.models.task import TaskOptions
 
@@ -194,11 +215,13 @@ class Aria2RpcServer(QObject):
         # filename 只绑定到 done，避免 failed 收到多余关键字参数（#645）
         self._coroutineRunner.submit(
             self._parse(taskOptions),
-            done=partial(self._onTaskParsed, filename=filename),
-            failed=self._onTaskParseFailed,
+            done=partial(self._onTaskParsed, gid, filename=filename),
+            failed=partial(self._onTaskParseFailed, gid),
         )
 
-    def _onTaskParsed(self, task: Task, filename: str = "") -> None:
+    def _onTaskParsed(self, gid: str, task: Task, filename: str = "") -> None:
+        self._gidRecords[gid].task = task
+
         if filename:
             task.setName(filename)
 
@@ -208,8 +231,63 @@ class Aria2RpcServer(QObject):
 
         self._addTask(task)
 
-    def _onTaskParseFailed(self, error: str) -> None:
+    def _onTaskParseFailed(self, gid: str, error: str) -> None:
+        self._gidRecords[gid].error = error
         logger.warning("Aria2 RPC task parse failed: {}", error)
+
+    def _tellStatus(self, socket: QTcpSocket, rpcId: Any, params: list) -> None:
+        gid = params[0] if params and isinstance(params[0], str) else ""
+        record = self._gidRecords.get(gid)
+        if record is None:
+            self._respondError(socket, rpcId, 1, f"No such download for GID#{gid}")
+            return
+        self._respond(socket, rpcId, self._buildStatus(gid, record))
+
+    def _buildStatus(self, gid: str, record: _GidRecord) -> dict:
+        # aria2 响应中所有值都是字符串
+        if record.error:
+            return {
+                "gid": gid,
+                "status": "error",
+                "totalLength": "0",
+                "completedLength": "0",
+                "downloadSpeed": "0",
+                "errorMessage": record.error,
+                "files": [],
+            }
+
+        task = record.task
+        if task is None:
+            return {
+                "gid": gid,
+                "status": "waiting",
+                "totalLength": "0",
+                "completedLength": "0",
+                "downloadSpeed": "0",
+                "files": [],
+            }
+
+        _, speed, receivedBytes = task.currentSnapshot()
+        status = _TASK_STATUS_TO_ARIA2[task.status]
+        totalLength = str(task.fileSize)
+        completedLength = str(receivedBytes)
+        result = {
+            "gid": gid,
+            "status": status,
+            "totalLength": totalLength,
+            "completedLength": completedLength,
+            "downloadSpeed": str(speed),
+            "files": [{
+                "index": "1",
+                "path": task.outputPath,
+                "length": totalLength,
+                "completedLength": completedLength,
+            }],
+        }
+        if status == "error":
+            error = task.lastError
+            result["errorMessage"] = str(error) if error else ""
+        return result
 
     def _respond(self, socket: QTcpSocket, rpcId: Any, result: Any) -> None:
         self._sendJson(socket, {"jsonrpc": "2.0", "id": rpcId, "result": result})

--- a/app/services/aria2_rpc.py
+++ b/app/services/aria2_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from functools import partial
 from pathlib import Path
 from secrets import token_hex
 from typing import TYPE_CHECKING, Any
@@ -189,11 +190,12 @@ class Aria2RpcServer(QObject):
             outputFolder=outputFolder,
             clientProfile=clientProfile,
         )
+        # CoroutineRunner 会把 kwargs 同时传给 done 和 failed，
+        # filename 只绑定到 done，避免 failed 收到多余关键字参数（#645）
         self._coroutineRunner.submit(
             self._parse(taskOptions),
-            done=self._onTaskParsed,
+            done=partial(self._onTaskParsed, filename=filename),
             failed=self._onTaskParseFailed,
-            filename=filename,
         )
 
     def _onTaskParsed(self, task: Task, filename: str = "") -> None:

--- a/app/services/aria2_rpc.py
+++ b/app/services/aria2_rpc.py
@@ -269,7 +269,8 @@ class Aria2RpcServer(QObject):
 
         _, speed, receivedBytes = task.currentSnapshot()
         status = _TASK_STATUS_TO_ARIA2[task.status]
-        totalLength = str(task.fileSize)
+        # fileSize 可能是 SpecialFileSize 哨兵值（UNKNOWN=0 / NOT_SUPPORTED=-1），aria2 语义均为 "0"
+        totalLength = str(max(task.fileSize, 0))
         completedLength = str(receivedBytes)
         result = {
             "gid": gid,

--- a/app/services/aria2_rpc.py
+++ b/app/services/aria2_rpc.py
@@ -271,7 +271,8 @@ class Aria2RpcServer(QObject):
         status = _TASK_STATUS_TO_ARIA2[task.status]
         # fileSize 可能是 SpecialFileSize 哨兵值（UNKNOWN=0 / NOT_SUPPORTED=-1），aria2 语义均为 "0"
         totalLength = str(max(task.fileSize, 0))
-        completedLength = str(receivedBytes)
+        # 完成后 step 的 receivedBytes 停留在最后一次采样值，可能小于 fileSize
+        completedLength = totalLength if task.status == TaskStatus.COMPLETED else str(receivedBytes)
         result = {
             "gid": gid,
             "status": status,

--- a/tests/test_aria2_rpc.py
+++ b/tests/test_aria2_rpc.py
@@ -128,3 +128,99 @@ class TestParseCallbackBinding:
         runner.done(task)
         assert task.name == "renamed.zip"
         assert added == [task]
+
+
+# ── aria2.tellStatus ──
+
+
+def tellStatus(srv, gid: str, rpcId: int = 2) -> dict:
+    socket = StubSocket()
+    srv._dispatchRpc(socket, json.dumps({
+        "jsonrpc": "2.0", "id": rpcId, "method": "aria2.tellStatus", "params": [gid],
+    }).encode())
+    return socket.response()
+
+
+class TestTellStatus:
+    def test_parse_pending_is_waiting(self, server):
+        srv, _, _ = server
+        gid, _ = addUri(srv)
+        result = tellStatus(srv, gid)["result"]
+        assert result["gid"] == gid
+        assert result["status"] == "waiting"
+        assert result["totalLength"] == "0"
+        assert result["completedLength"] == "0"
+        assert result["downloadSpeed"] == "0"
+
+    def test_running_task_is_active(self, server, tmp_path):
+        srv, runner, _ = server
+        gid, _ = addUri(srv)
+        task = makeTask()
+        task.outputFolder = tmp_path
+        task.fileSize = 200
+        step = task.steps[0]
+        step.status = TaskStatus.RUNNING
+        step.speed = 100
+        step.receivedBytes = 50
+        task.updateStatus()
+        runner.done(task)
+
+        result = tellStatus(srv, gid)["result"]
+        assert result["status"] == "active"
+        assert result["totalLength"] == "200"
+        assert result["completedLength"] == "50"
+        assert result["downloadSpeed"] == "100"
+        assert result["files"] == [{
+            "index": "1",
+            "path": str(tmp_path / "test.zip"),
+            "length": "200",
+            "completedLength": "50",
+        }]
+
+    def test_completed_task_is_complete(self, server):
+        srv, runner, _ = server
+        gid, _ = addUri(srv)
+        task = makeTask()
+        task.fileSize = 200
+        step = task.steps[0]
+        step.receivedBytes = 200
+        step.setStatus(TaskStatus.COMPLETED)
+        runner.done(task)
+
+        result = tellStatus(srv, gid)["result"]
+        assert result["status"] == "complete"
+        assert result["completedLength"] == "200"
+        assert result["downloadSpeed"] == "0"
+
+    def test_parse_failure_is_error_with_message(self, server):
+        srv, runner, _ = server
+        gid, _ = addUri(srv)
+        runner.failed("no parser matched")
+
+        result = tellStatus(srv, gid)["result"]
+        assert result["status"] == "error"
+        assert result["errorMessage"] == "no parser matched"
+
+    def test_all_values_are_strings(self, server):
+        srv, runner, _ = server
+        gid, _ = addUri(srv)
+        task = makeTask()
+        task.fileSize = 200
+        step = task.steps[0]
+        step.status = TaskStatus.RUNNING
+        step.speed = 100
+        step.receivedBytes = 50
+        task.updateStatus()
+        runner.done(task)
+
+        result = tellStatus(srv, gid)["result"]
+        for key in ("gid", "status", "totalLength", "completedLength", "downloadSpeed"):
+            assert isinstance(result[key], str), key
+        for key in ("index", "path", "length", "completedLength"):
+            assert isinstance(result["files"][0][key], str), key
+
+    def test_unknown_gid_error(self, server):
+        srv, _, _ = server
+        response = tellStatus(srv, "deadbeef")
+        assert response["error"]["code"] == 1
+        assert response["error"]["message"] == "No such download for GID#deadbeef"

--- a/tests/test_aria2_rpc.py
+++ b/tests/test_aria2_rpc.py
@@ -1,0 +1,130 @@
+"""Aria2RpcServer 的回调与 tellStatus 测试。
+
+覆盖 #645 回归（解析失败回调收到多余 kwargs 导致 TypeError）。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from app.models.task import Task, TaskStep, TaskStatus
+from app.services.aria2_rpc import Aria2RpcServer
+
+
+# ── Stubs ──
+
+
+@dataclass(kw_only=True)
+class StubStep(TaskStep):
+    stepIndex: int = 0
+
+    async def run(self, reportSpeed, waitForSpeedLimit):
+        pass
+
+
+class StubCoroutineRunner:
+    """捕获 submit 的回调，由测试手动触发 done/failed。"""
+
+    def __init__(self):
+        self.done = None
+        self.failed = None
+        self.kwargs = {}
+
+    def submit(self, work, done=None, failed=None, **kwargs) -> str:
+        if asyncio.iscoroutine(work):
+            work.close()  # 不真正执行，避免未 await 警告
+        self.done = done
+        self.failed = failed
+        self.kwargs = kwargs
+        return "wrk_1"
+
+
+class StubSocket:
+    def __init__(self):
+        self.written = b""
+
+    def write(self, data: bytes):
+        self.written += data
+
+    def flush(self):
+        pass
+
+    def disconnectFromHost(self):
+        pass
+
+    def response(self) -> dict:
+        body = self.written.split(b"\r\n\r\n", 1)[1]
+        return json.loads(body)
+
+
+# ── Fixtures ──
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    from PySide6.QtWidgets import QApplication
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def server(qapp, monkeypatch, tmp_path):
+    from app.config.cfg import cfg
+    monkeypatch.setattr(cfg.aria2RpcToken, "value", "")
+    monkeypatch.setattr(cfg.downloadFolder, "value", str(tmp_path))
+    monkeypatch.setattr(cfg.aria2RpcEmulateFingerprint, "value", False)
+    monkeypatch.setattr(cfg.shouldDraftTakenDownload, "value", False)
+
+    runner = StubCoroutineRunner()
+    added: list[Task] = []
+
+    async def parse(taskOptions):
+        raise AssertionError("测试不应真正执行 parse")
+
+    srv = Aria2RpcServer(runner, parse, added.append)
+    return srv, runner, added
+
+
+def makeTask(name: str = "test.zip") -> Task:
+    step = StubStep(stepIndex=0)
+    task = Task(name=name, url="http://test/file.zip", packId="http", steps=[step])
+    step._bindTask(task)
+    return task
+
+
+def addUri(srv, options: dict | None = None, rpcId: int = 1) -> tuple[str, StubSocket]:
+    socket = StubSocket()
+    params: list = [["http://test/file.zip"]]
+    if options is not None:
+        params.append(options)
+    srv._dispatchRpc(socket, json.dumps({
+        "jsonrpc": "2.0", "id": rpcId, "method": "aria2.addUri", "params": params,
+    }).encode())
+    return socket.response()["result"], socket
+
+
+# ── #645: 解析失败回调 TypeError ──
+
+
+class TestParseCallbackBinding:
+    def test_filename_not_passed_as_submit_kwarg(self, server):
+        srv, runner, _ = server
+        addUri(srv, options={"out": "name.zip"})
+        # CoroutineRunner 会把 kwargs 同时透传给 done 和 failed，
+        # filename 只能绑定在 done 上（#645）
+        assert "filename" not in runner.kwargs
+
+    def test_failed_callback_accepts_error_only(self, server):
+        srv, runner, _ = server
+        addUri(srv, options={"out": "name.zip"})
+        runner.failed("boom")  # 不应 TypeError
+
+    def test_done_callback_applies_filename_and_adds_task(self, server):
+        srv, runner, added = server
+        addUri(srv, options={"out": "renamed.zip"})
+        task = makeTask()
+        runner.done(task)
+        assert task.name == "renamed.zip"
+        assert added == [task]

--- a/tests/test_aria2_rpc.py
+++ b/tests/test_aria2_rpc.py
@@ -177,6 +177,20 @@ class TestTellStatus:
             "completedLength": "50",
         }]
 
+    def test_sentinel_file_size_reports_zero_total(self, server):
+        srv, runner, _ = server
+        gid, _ = addUri(srv)
+        task = makeTask()
+        task.fileSize = -1  # SpecialFileSize.NOT_SUPPORTED
+        step = task.steps[0]
+        step.status = TaskStatus.RUNNING
+        task.updateStatus()
+        runner.done(task)
+
+        result = tellStatus(srv, gid)["result"]
+        assert result["totalLength"] == "0"
+        assert result["files"][0]["length"] == "0"
+
     def test_completed_task_is_complete(self, server):
         srv, runner, _ = server
         gid, _ = addUri(srv)

--- a/tests/test_aria2_rpc.py
+++ b/tests/test_aria2_rpc.py
@@ -197,7 +197,8 @@ class TestTellStatus:
         task = makeTask()
         task.fileSize = 200
         step = task.steps[0]
-        step.receivedBytes = 200
+        # 完成后 receivedBytes 停留在最后一次采样值（真实下载中常小于 fileSize）
+        step.receivedBytes = 150
         step.setStatus(TaskStatus.COMPLETED)
         runner.done(task)
 


### PR DESCRIPTION
### What

Adds **`aria2.tellStatus`** to the aria2-compat RPC and fixes #645 along the way. Third-party tools that push tasks via `aria2.addUri` can now poll download state through the same interface, instead of having to watch the output file / `.ghd` sidecar from outside.

Commits:

1. `fix(Aria2Rpc)`: #645 — `filename` was forwarded to both callbacks via `CoroutineRunner.submit(**kwargs)`, so `_onTaskParseFailed` raised `TypeError` on every RPC parse failure and the real error was swallowed. Now bound to the done-callback only via `functools.partial`, with a regression test.
2. `feat(Aria2Rpc)`: `aria2.tellStatus`. The server now keeps a `gid → _GidRecord` map (pending / parsed `Task` / parse-error). Status mapping: parse-pending → `waiting`, `TaskStatus` WAITING/RUNNING/PAUSED/COMPLETED/FAILED → `waiting`/`active`/`paused`/`complete`/`error`. All values are strings per aria2 convention; unknown gid → error code 1, `No such download for GID#<gid>` (aria2 wording). Progress/speed reuse `task.currentSnapshot()`.
3. Two conformance fixes found in live testing: sentinel `fileSize` values (`UNKNOWN=0` / `NOT_SUPPORTED=-1`) serialize as `totalLength "0"`, and completed tasks report `completedLength == totalLength` (step `receivedBytes` rests at the last supervise sample, which can be below `fileSize`).

### Why

The RPC currently supports only `addUri` + `getVersion`, so automation that pushes a task gets a gid it can do nothing with (context: #644 investigation). `tellStatus` is the minimum aria2 surface that makes the gid meaningful.

### Testing

- `tests/test_aria2_rpc.py` (10 tests): callback binding regression for #645, tellStatus for pending / active / complete / parse-failed / sentinel-size / unknown-gid, all-values-are-strings. Fake `parse`/`addTask` injected; no network.
- Full suite: `QT_QPA_PLATFORM=offscreen uv run pytest tests/ -q` → **215 passed** (205 on main).
- Live end-to-end on Linux (headless, offscreen): pushed a real 59 MB download via RPC and polled —

  mid-flight:
  ```json
  {"gid": "15f8f78b...", "status": "active", "totalLength": "59178912", "completedLength": "27569500", "downloadSpeed": "27569500", "files": [{"index": "1", "path": ".../tellstatus-e2e2.deb", "length": "59178912", "completedLength": "27569500"}]}
  ```
  after completion:
  ```json
  {"gid": "15f8f78b...", "status": "complete", "totalLength": "59178912", "completedLength": "59178912", "downloadSpeed": "0", ...}
  ```
  unknown gid:
  ```json
  {"error": {"code": 1, "message": "No such download for GID#deadbeef00000000"}}
  ```

### Notes / open points

- `_gidRecords` is unbounded (grows per `addUri`, holds `Task` refs). Real aria2 also retains results until purged (default `--max-download-result=1000`). Happy to add a size cap or an `aria2.purgeDownloadResult` follow-up if you'd prefer — kept this PR minimal.
- The `keys` filter param of `tellStatus` is accepted but not applied (full object returned); aria2 clients tolerate extra keys.

Closes #645.
