### PR TITLE
fix(i18n): 导航项文本溢出

### DIFF
--- a/app/assets/i18n/gd3.en_US.ts
+++ b/app/assets/i18n/gd3.en_US.ts
@@ -1041,7 +1041,7 @@ Only allow this request if you have requested &quot;Automatic Pair&quot; from th
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="52"/>
         <source>资源下载</source>
-        <translation>Resource Downloads</translation>
+        <translation>Resource</translation>
     </message>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="110"/>

--- a/app/assets/i18n/gd3.ja_JP.ts
+++ b/app/assets/i18n/gd3.ja_JP.ts
@@ -1041,7 +1041,7 @@ http://example.com/{mp4,mkv}/video</translation>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="52"/>
         <source>资源下载</source>
-        <translation>リソースダウンロード</translation>
+        <translation>リソース</translation>
     </message>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="110"/>

--- a/app/assets/i18n/gd3.pt_BR.ts
+++ b/app/assets/i18n/gd3.pt_BR.ts
@@ -747,7 +747,7 @@ http://example.com/{mp4,mkv}/video</translation>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="52"/>
         <source>资源下载</source>
-        <translation>Download de recursos</translation>
+        <translation>Recursos</translation>
     </message>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="110"/>

--- a/app/assets/i18n/gd3.ru_RU.ts
+++ b/app/assets/i18n/gd3.ru_RU.ts
@@ -1041,7 +1041,7 @@ http://example.com/{mp4,mkv}/video</translation>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="52"/>
         <source>资源下载</source>
-        <translation>Загрузка ресурсов</translation>
+        <translation>Ресурсы</translation>
     </message>
     <message>
         <location filename="../../../features/jack_yao/pack.py" line="110"/>


### PR DESCRIPTION
<!-- To use the English pull request template, create your PR with `template=en.md`. -->
<!-- Example: https://github.com/XiaoYouChR/Ghost-Downloader-3/compare/main...your-branch?quick_pull=1&template=en.md -->

<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->
<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，Ghost-Downloader-3 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## PR 描述

<img width="227" height="327" alt="image_353" src="https://github.com/user-attachments/assets/26ef661e-c605-42ec-855b-b3c78cf22c77" />

在非中文界面下，侧边栏导航项“资源下载”的部分 i18n 文本会被裁剪

PySide6-Fluent-Widgets 的 `MSFluentWindow` 侧边栏导航按钮宽度固定为 64px 非中文译文长度超过可绘制区域时会被直接裁剪


## PR 类型

Bug 修复

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新