### PR TITLE
feat: 为主窗口标题栏添加类 WinUI-Subtile 副标题组件实现

### DIFF
--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -75,9 +75,9 @@ class MainWindow(MSFluentWindow):
         self._refreshBackgroundEffect()
         self.titleBar.hBoxLayout.insertSpacing(2, 6)
         titleLabel = self.titleBar.titleLabel
-        titleWidth = titleLabel.contentsMargins().left() + titleLabel.fontMetrics().horizontalAdvance(titleLabel.text())
-        titleLabel.setFixedWidth(titleWidth)
-        self.subtitleLabel = CaptionLabel(f"v{VERSION}", self.titleBar)
+        titleLabel.setContentsMargins(titleLabel.contentsMargins().left(), 0, 0, 0)
+        titleLabel.adjustSize()
+        self.subtitleLabel = CaptionLabel(f" v{VERSION}", self.titleBar)
         self.subtitleLabel.setTextColor("#9E000000", "#C5FFFFFF")
         self.titleBar.hBoxLayout.insertWidget(self.titleBar.hBoxLayout.indexOf(titleLabel) + 1, self.subtitleLabel)
         if sys.platform == "darwin":

--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -9,11 +9,11 @@ from PySide6.QtGui import QColor, QIcon, QDesktopServices, QPalette
 from PySide6.QtWidgets import QApplication, QHBoxLayout, QWidget
 from qfluentwidgets import (
     MSFluentWindow, FluentIcon, NavigationItemPosition, MessageBox, Theme, InfoBar, InfoBarPosition,
-    SearchLineEdit, setThemeColor,
+    CaptionLabel, SearchLineEdit, setThemeColor,
 )
 
 from app.config.cfg import CloseMode, cfg
-from app.config.constants import AUTHOR_URL, FEEDBACK_URL
+from app.config.constants import AUTHOR_URL, FEEDBACK_URL, VERSION
 from app.services.task_draft import TaskDraft
 from app.signal_bus import signalBus
 from app.view.pages.setting_page import SettingPage
@@ -47,6 +47,7 @@ class MainWindow(MSFluentWindow):
         self._isGeometryRestored = False
         self._isBackgroundEffectDirty = False
         self.searchEdit = None
+        self.subtitleLabel = None
         super().__init__(parent)
         self._taskService = taskService
         self._featureService = featureService
@@ -73,6 +74,12 @@ class MainWindow(MSFluentWindow):
         self.setMinimumSize(960, 540)
         self._refreshBackgroundEffect()
         self.titleBar.hBoxLayout.insertSpacing(2, 6)
+        titleLabel = self.titleBar.titleLabel
+        titleWidth = titleLabel.contentsMargins().left() + titleLabel.fontMetrics().horizontalAdvance(titleLabel.text())
+        titleLabel.setFixedWidth(titleWidth)
+        self.subtitleLabel = CaptionLabel(f"v{VERSION}", self.titleBar)
+        self.subtitleLabel.setTextColor("#9E000000", "#C5FFFFFF")
+        self.titleBar.hBoxLayout.insertWidget(self.titleBar.hBoxLayout.indexOf(titleLabel) + 1, self.subtitleLabel)
         if sys.platform == "darwin":
             self.titleBar.hBoxLayout.insertSpacing(0, 60)
 
@@ -365,6 +372,9 @@ class MainWindow(MSFluentWindow):
 
     def changeEvent(self, event) -> None:
         super().changeEvent(event)
+        if event.type() == QEvent.Type.ActivationChange and self.subtitleLabel is not None:
+            subtitleColors = ("#9E000000", "#C5FFFFFF") if self.isActiveWindow() else ("#72000000", "#87FFFFFF")
+            self.subtitleLabel.setTextColor(*subtitleColors)
         if event.type() == QEvent.Type.PaletteChange:
             self.refreshThemeColor()
         if self._isBackgroundEffectDirty and event.type() == QEvent.Type.ThemeChange:


### PR DESCRIPTION

<img width="421" height="121" alt="image_359" src="https://github.com/user-attachments/assets/02eae44a-5e62-4349-8148-0ea0543d6b91" />



## PR 描述

为桌面端主窗口标题栏添加 WinUI 3 风格的 Subtitle 用于在应用标题右侧显示当前版本号
- 使用 `app.config.constants.VERSION` 作为唯一版本来源

## PR 类型

- 功能

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

## 备注

### WinUI 对 Subtitle 用途的声明

Microsoft 在 `TitleBar.Subtitle` API 文档中声明，Subtitle 显示在标题右侧，通常用于显示版本相关信息，例如 `Preview` ＆ `Beta` 本 PR 遵循该语义，将其用于显示 Ghost Downloader 当前版本号


### 参考

[TitleBar.Subtitle API]：https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.titlebar.subtitle

[WinUI TitleBar 功能规范]：https://github.com/microsoft/microsoft-ui-xaml/blob/main/specs/TitleBar/titlebar-functional-spec.md

[WinUI 通用文字颜色资源]：https://github.com/microsoft/microsoft-ui-xaml/blob/main/controls/dev/CommonStyles/Common_themeresources_any.xaml