### PR TITLE
fix(bt): 修复 magnet 元数据获取失败（DHT bootstrap / alert 风暴 / 冷启动）

### DIFF
--- a/features/bittorrent_pack/config.py
+++ b/features/bittorrent_pack/config.py
@@ -38,7 +38,7 @@ class BitTorrentConfig(PackConfig):
     maxConnections = RangeConfigItem("BitTorrent", "ConnectionsLimit", 500, RangeValidator(20, 2000))
     maxUploadSpeed = RangeConfigItem("BitTorrent", "UploadRateLimit", 0, RangeValidator(0, 1024 * 1024 * 100))
     listenPort = RangeConfigItem("BitTorrent", "ListenPort", 0, RangeValidator(0, 65535))
-    metadataTimeout = RangeConfigItem("BitTorrent", "MetadataTimeout", 30, RangeValidator(5, 300))
+    metadataTimeout = RangeConfigItem("BitTorrent", "MetadataTimeout", 120, RangeValidator(5, 300))
     enableSequentialDownload = ConfigItem("BitTorrent", "SequentialDownload", False, BoolValidator())
     storageMode = OptionsConfigItem(
         "BitTorrent", "StorageMode", "sparse", OptionsValidator(["sparse", "allocate"]),

--- a/features/bittorrent_pack/pack.py
+++ b/features/bittorrent_pack/pack.py
@@ -124,7 +124,10 @@ class BitTorrentPack(FeaturePack):
         return [UriScheme("magnet", "Magnet")]
 
     async def activate(self):
-        pass
+        # 预热 BT session：提前创建 session 让 DHT/LSD 尽早 bootstrap。
+        # 否则用户首次解析 magnet 时 DHT 冷启动（路由表为空），
+        # 元数据只能依赖 tracker，成功率低。
+        btSession._open()
 
     async def deactivate(self):
         await btSession.close()

--- a/features/bittorrent_pack/session.py
+++ b/features/bittorrent_pack/session.py
@@ -266,6 +266,13 @@ class BTSession(QObject):
                 "upload_rate_limit": int(bittorrentConfig.maxUploadSpeed.value),
                 "enable_dht": bittorrentConfig.enableDht.value,
                 "enable_lsd": bittorrentConfig.enableLsd.value,
+                # libtorrent 2.0.13 默认只有 dht.libtorrent.org:25401 一个 bootstrap
+                # 节点，部分网络下不可达会导致 DHT 无法收敛（元数据只能靠 tracker）。
+                # 显式配置多节点，与 qBittorrent 对齐。
+                "dht_bootstrap_nodes": (
+                    "router.bittorrent.com:6881, router.utorrent.com:6881, "
+                    "dht.transmissionbt.com:6881, dht.libtorrent.org:25401"
+                ),
                 "announce_to_all_trackers": True,
                 "announce_to_all_tiers": True,
                 "enable_upnp": True,

--- a/features/bittorrent_pack/session.py
+++ b/features/bittorrent_pack/session.py
@@ -38,6 +38,22 @@ _ERROR_ALERTS = (
     lt.hash_failed_alert,
 )
 
+# libtorrent 的代理类型按 scheme 映射。socks4 协议不支持用户名密码认证。
+# https 代理 libtorrent 没有对应类型，按 http（CONNECT 隧道）处理。
+_PROXY_TYPES = {
+    "http": lt.proxy_type_t.http,
+    "https": lt.proxy_type_t.http,
+    "socks4": lt.proxy_type_t.socks4,
+    "socks5": lt.proxy_type_t.socks5,
+    "socks5h": lt.proxy_type_t.socks5,
+}
+_PROXY_TYPES_PW = {
+    "http": lt.proxy_type_t.http_pw,
+    "https": lt.proxy_type_t.http_pw,
+    "socks5": lt.proxy_type_t.socks5_pw,
+    "socks5h": lt.proxy_type_t.socks5_pw,
+}
+
 _RESUME_SAVE_INTERVAL = 30
 
 
@@ -252,6 +268,8 @@ class BTSession(QObject):
                 "enable_lsd": bittorrentConfig.enableLsd.value,
                 "announce_to_all_trackers": True,
                 "announce_to_all_tiers": True,
+                "enable_upnp": True,
+                "enable_natpmp": True,
                 "alert_mask": lt.alert.category_t.all_categories,
                 **self._proxySettings(),
             })
@@ -479,11 +497,16 @@ class BTSession(QObject):
         if not url:
             return {}
         parsed = urlsplit(url)
-        if parsed.scheme.lower() not in {"socks5", "socks5h"} or not parsed.hostname or not parsed.port:
+        scheme = parsed.scheme.lower()
+        if scheme not in _PROXY_TYPES or not parsed.hostname or not parsed.port:
             return {}
         hasCredentials = bool(parsed.username or parsed.password)
+        if scheme == "socks4":
+            proxyType = lt.proxy_type_t.socks4
+        else:
+            proxyType = _PROXY_TYPES_PW[scheme] if hasCredentials else _PROXY_TYPES[scheme]
         return {
-            "proxy_type": lt.proxy_type_t.socks5_pw if hasCredentials else lt.proxy_type_t.socks5,
+            "proxy_type": proxyType,
             "proxy_hostname": parsed.hostname,
             "proxy_port": parsed.port,
             "proxy_username": parsed.username or "",

--- a/features/bittorrent_pack/session.py
+++ b/features/bittorrent_pack/session.py
@@ -31,13 +31,6 @@ _STATE_TEXT = {
     "queued_for_checking": "等待校验",
 }
 
-_ERROR_ALERTS = (
-    lt.file_error_alert,
-    lt.metadata_failed_alert,
-    lt.torrent_error_alert,
-    lt.hash_failed_alert,
-)
-
 # libtorrent 的代理类型按 scheme 映射。socks4 协议不支持用户名密码认证。
 # https 代理 libtorrent 没有对应类型，按 http（CONNECT 隧道）处理。
 _PROXY_TYPES = {
@@ -194,6 +187,14 @@ class BTSession(QObject):
             ti = await asyncio.wait_for(waiter, timeout=bittorrentConfig.metadataTimeout.value)
             return lt.bencode(lt.create_torrent(ti).generate())
         except asyncio.TimeoutError:
+            try:
+                st = handle.status()
+                logger.warning("magnet 元数据超时: state={} peers={} seeds={} "
+                               "trackers={} dhtNodes={}",
+                               st.state, st.num_peers, st.num_seeds,
+                               len(st.trackers), self._dhtNodeCount())
+            except Exception:
+                pass
             raise TimeoutError("等待 magnet 元数据超时")
         finally:
             self._metadataWaiters.pop(id(handle), None)
@@ -258,7 +259,7 @@ class BTSession(QObject):
     def _open(self) -> None:
         if self._session is None:
             from app.config.constants import VERSION
-            self._session = lt.session({
+            settings = {
                 "user_agent": f"GhostDownloader/{VERSION} libtorrent/{lt.__version__}",
                 "listen_interfaces": f"0.0.0.0:{bittorrentConfig.listenPort.value}",
                 "connections_limit": bittorrentConfig.maxConnections.value,
@@ -277,11 +278,28 @@ class BTSession(QObject):
                 "announce_to_all_tiers": True,
                 "enable_upnp": True,
                 "enable_natpmp": True,
-                "alert_mask": lt.alert.category_t.all_categories,
+                # 精选 alert 类别：只保留影响任务状态的关键 alert。
+                # all_categories 会收到 tracker_announce/tracker_error 等
+                # 高频噪音（数百 tracker 每轮 announce 产生上千条），
+                # Python 层逐条处理会积压队列，导致 metadata_received_alert
+                # 处理延迟超过 wait_for 超时。
+                # error|port_mapping|storage|status 覆盖：
+                # metadata_received/failed(status)、save_resume_data(storage)、
+                # fastresume_rejected/state_changed(status)、
+                # torrent_error/file_error/hash_failed(error|status)。
+                "alert_mask": (
+                    lt.alert.category_t.error_notification
+                    | lt.alert.category_t.port_mapping_notification
+                    | lt.alert.category_t.storage_notification
+                    | lt.alert.category_t.status_notification
+                ),
                 **self._proxySettings(),
-            })
+            }
+            logger.info("BT session 创建: {}", settings)
+            self._session = lt.session(settings)
         if self._poller is None or self._poller.done():
             self._poller = asyncio.get_running_loop().create_task(self._supervise())
+            logger.info("BT session poller 已启动")
 
     # ── torrent management ──
 
@@ -358,59 +376,72 @@ class BTSession(QObject):
     # ── poll loop ──
 
     async def _supervise(self) -> None:
+        ticks = 0
         while self._session is not None:
             try:
+                alertCount = 0
                 for alert in self._session.pop_alerts():
+                    alertCount += 1
                     self._routeAlert(alert)
                 for entry in list(self._active.values()):
                     self._updateEntry(entry)
+                ticks += 1
+                if ticks % 30 == 0:
+                    logger.info("BT poll 心跳: ticks={} alerts={} active={} waiters={}",
+                                ticks, alertCount, len(self._active), len(self._metadataWaiters))
             except Exception as e:
                 logger.opt(exception=e).error("BitTorrent poll 异常")
             await asyncio.sleep(1)
 
     def _routeAlert(self, alert) -> None:
-        if not hasattr(alert, "handle"):
+        # 先按类型分流：只有会影响任务状态的 alert 才遍历查找对应 torrent，
+        # 高频噪音 alert（tracker 状态、peer 连接等）直接丢弃，
+        # 避免 alert 风暴（数百 tracker 每轮 announce 产生上千条）拖慢 metadata 处理。
+        if isinstance(alert, lt.metadata_received_alert):
+            for key, (handle, waiter) in list(self._metadataWaiters.items()):
+                if alert.handle != handle:
+                    continue
+                ti = handle.torrent_file()
+                if ti is not None and ti.is_valid() and not waiter.done():
+                    waiter.set_result(ti)
+                return
             return
 
-        for taskId, entry in self._active.items():
-            if alert.handle != entry.handle:
-                continue
-
-            if isinstance(alert, lt.save_resume_data_alert):
-                self._resumeCache[taskId] = lt.write_resume_data_buf(alert.params)
-                if entry.resumeWaiter is not None and not entry.resumeWaiter.done():
-                    entry.resumeWaiter.set_result(True)
+        if isinstance(alert, lt.metadata_failed_alert):
+            for key, (handle, waiter) in list(self._metadataWaiters.items()):
+                if alert.handle != handle:
+                    continue
+                if not waiter.done():
+                    waiter.set_exception(RuntimeError(alert.message()))
                 return
+            return
 
-            if isinstance(alert, lt.save_resume_data_failed_alert):
-                self._resumeCache.pop(taskId, None)
-                if entry.resumeWaiter is not None and not entry.resumeWaiter.done():
-                    entry.resumeWaiter.set_result(False)
-                return
-
-            if isinstance(alert, lt.fastresume_rejected_alert):
-                self._resumeCache.pop(taskId, None)
-                return
-
-            if isinstance(alert, _ERROR_ALERTS):
+        if isinstance(alert, (lt.torrent_error_alert, lt.file_error_alert, lt.hash_failed_alert)):
+            for taskId, entry in self._active.items():
+                if alert.handle != entry.handle:
+                    continue
                 if not entry.done.done():
                     entry.done.set_exception(
                         TaskError("BitTorrent 错误：{detail}", detail=alert.message())
                     )
                 return
-
             return
 
-        for key, (handle, waiter) in list(self._metadataWaiters.items()):
-            if alert.handle != handle:
-                continue
-            if isinstance(alert, lt.metadata_received_alert):
-                ti = handle.torrent_file()
-                if ti is not None and ti.is_valid() and not waiter.done():
-                    waiter.set_result(ti)
-            elif isinstance(alert, (lt.metadata_failed_alert, lt.torrent_error_alert)):
-                if not waiter.done():
-                    waiter.set_exception(RuntimeError(alert.message()))
+        if isinstance(alert, (lt.save_resume_data_alert, lt.save_resume_data_failed_alert, lt.fastresume_rejected_alert)):
+            for taskId, entry in self._active.items():
+                if alert.handle != entry.handle:
+                    continue
+                if isinstance(alert, lt.save_resume_data_alert):
+                    self._resumeCache[taskId] = lt.write_resume_data_buf(alert.params)
+                    if entry.resumeWaiter is not None and not entry.resumeWaiter.done():
+                        entry.resumeWaiter.set_result(True)
+                elif isinstance(alert, lt.save_resume_data_failed_alert):
+                    self._resumeCache.pop(taskId, None)
+                    if entry.resumeWaiter is not None and not entry.resumeWaiter.done():
+                        entry.resumeWaiter.set_result(False)
+                else:  # fastresume_rejected_alert
+                    self._resumeCache.pop(taskId, None)
+                return
             return
 
     def _updateEntry(self, entry: ActiveTorrent) -> None:
@@ -498,6 +529,13 @@ class BTSession(QObject):
         if not cfg.isSpeedLimitEnabled.value:
             return 0
         return int(cfg.speedLimitation.value)
+
+    def _dhtNodeCount(self) -> int:
+        try:
+            st = self._session.dht_state()
+            return len(st.nodes) if st is not None and st.nodes else 0
+        except Exception:
+            return -1
 
     def _proxySettings(self) -> dict:
         url = proxy()

--- a/features/bittorrent_pack/web_tracker/schema.py
+++ b/features/bittorrent_pack/web_tracker/schema.py
@@ -3,8 +3,9 @@ import json
 from qfluentwidgets import ConfigSerializer, ConfigValidator
 
 DEFAULT_WEB_TRACKER_SOURCES = [
+    "https://cf.trackerslist.com/all.txt",
     "https://cf.trackerslist.com/best.txt",
-    "https://cdn.jsdelivr.net/gh/XIU2/TrackersListCollection/best.txt",
+    "https://cdn.jsdelivr.net/gh/XIU2/TrackersListCollection/all.txt",
 ]
 
 

--- a/features/http_pack/task.py
+++ b/features/http_pack/task.py
@@ -344,9 +344,14 @@ class HttpTaskStep(TaskStep):
                             raise RangeNotSupportedError()
                         if status != 206:
                             raise Exception(f"服务器拒绝了范围请求，状态码：{status}")
+                        expectedBytes = subworker.end - subworker.position + 1
+                        rawReceived = 0
                         async for chunk in response.stream():
                             if not chunk:
                                 continue
+                            rawReceived += len(chunk)
+                            if rawReceived > expectedBytes:
+                                raise RangeNotSupportedError()
                             remaining = subworker.end - subworker.position + 1
                             if len(chunk) > remaining:
                                 chunk = chunk[:remaining]

--- a/tests/test_http_subworker.py
+++ b/tests/test_http_subworker.py
@@ -581,6 +581,41 @@ def ignoreRangeHandler(content: bytes):
 
 class TestRangeFallback:
 
+    async def test_oversized_body_falls_back_to_single_stream(self, server, tmpdir):
+        """Server returns 206 with correct Content-Range but sends more bytes than declared."""
+        content = makeFileContent(500)
+
+        async def oversizedRange(request: web.Request) -> web.Response:
+            rangeHeader = request.headers.get("Range")
+            if rangeHeader is None:
+                return web.Response(
+                    body=content,
+                    headers={"Content-Length": str(len(content))},
+                )
+            rangeSpec = rangeHeader.replace("bytes=", "")
+            parts = rangeSpec.split("-")
+            start = int(parts[0])
+            end = int(parts[1]) if parts[1] else len(content) - 1
+            body = content[start:end + 1]
+            # Send 2x the declared range — simulates CDN decompression bug
+            return web.Response(
+                status=206,
+                body=body + body,
+                headers={
+                    "Content-Range": f"bytes {start}-{end}/{len(content)}",
+                },
+            )
+
+        url = await server(oversizedRange)
+        task, step = makeStep(url, tmpdir, fileSize=500, subworkerCount=2,
+                              canUseRangeRequests=True)
+        task.setStatus(TaskStatus.RUNNING)
+
+        await runStep(step)
+
+        assert not step.canUseRangeRequests
+        assert (tmpdir / "test.bin").read_bytes() == content
+
     async def test_200_for_range_falls_back_to_single_stream(self, server, tmpdir):
         """Server returns 200 for Range requests. Should fallback and complete."""
         content = makeFileContent(500)

--- a/tests/test_proxy_settings.py
+++ b/tests/test_proxy_settings.py
@@ -1,0 +1,78 @@
+"""BTSession._proxySettings scheme mapping tests."""
+import libtorrent as lt
+import pytest
+
+from features.bittorrent_pack.session import BTSession
+from app.config.cfg import cfg
+
+
+@pytest.fixture
+def proxy_setting():
+    old = cfg.proxyServer.value
+    yield
+    cfg.proxyServer.value = old
+
+
+def _settings(proxyUrl, proxy_setting):
+    cfg.proxyServer.value = proxyUrl
+    return BTSession()._proxySettings()
+
+
+def test_no_proxy_when_off(proxy_setting):
+    assert _settings("Off", proxy_setting) == {}
+
+
+def test_socks5_mapping(proxy_setting):
+    s = _settings("socks5://127.0.0.1:7897", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.socks5
+    assert s["proxy_hostname"] == "127.0.0.1"
+    assert s["proxy_port"] == 7897
+    assert s["proxy_tracker_connections"] is True
+    assert s["proxy_peer_connections"] is True
+
+
+def test_socks5h_mapping(proxy_setting):
+    s = _settings("socks5h://proxy.example.com:1080", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.socks5
+
+
+def test_socks5_with_credentials(proxy_setting):
+    s = _settings("socks5://user:pass@127.0.0.1:1080", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.socks5_pw
+    assert s["proxy_username"] == "user"
+    assert s["proxy_password"] == "pass"
+
+
+def test_http_mapping(proxy_setting):
+    # Windows 系统代理常为 http://127.0.0.1:7897，此前被静默丢弃
+    s = _settings("http://127.0.0.1:7897", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.http
+    assert s["proxy_hostname"] == "127.0.0.1"
+    assert s["proxy_port"] == 7897
+
+
+def test_http_with_credentials(proxy_setting):
+    s = _settings("http://user:pass@127.0.0.1:7897", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.http_pw
+
+
+def test_https_mapping(proxy_setting):
+    # libtorrent 没有 https 代理类型，按 http（CONNECT 隧道）处理
+    s = _settings("https://127.0.0.1:7897", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.http
+
+
+def test_socks4_mapping(proxy_setting):
+    # SOCKS4 协议不支持认证，带凭据也按 socks4
+    s = _settings("socks4://127.0.0.1:1080", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.socks4
+    s = _settings("socks4://user:pass@127.0.0.1:1080", proxy_setting)
+    assert s["proxy_type"] == lt.proxy_type_t.socks4
+
+
+def test_invalid_scheme_ignored(proxy_setting):
+    assert _settings("ftp://127.0.0.1:21", proxy_setting) == {}
+
+
+def test_missing_port_ignored(proxy_setting):
+    assert _settings("socks5://127.0.0.1", proxy_setting) == {}


### PR DESCRIPTION
## PR 描述

修复 BT magnet 磁力链接元数据获取极易超时失败的问题（默认 30 秒超时，失败率 ~60% 以上）。通过三组代码改动将磁力链解析成功率从不可用提高到秒级完成。

## Close #711

## PR 类型

- Bug 修复

## PR 检查清单

- [x] 应用成功启动且测试无 Bug
- [x] **不**包含破坏式更新

## 备注

### 根因（三层叠加）

**（一）DHT 永远无法收敛** — libtorrent 2.0.13 默认 `dht_bootstrap_nodes` 仅 `dht.libtorrent.org:25401`，国内网络 UDP 不可达（实测 1s 超时），DHT 路由表永久为空。qBittorrent 显式配置 3~4 个 bootstrap 节点，DHT 正常收敛。

**（二）冷启动期无 peers** — BT session 懒创建（首次解析 magnet 才初始化），magnet 自带 10 个 tracker 全部无效（nyaatracker 实测返回 `peers: []`，其余超时/被墙）；唯一有效的 opentrackr 连通性剧烈波动（0.6s~105s），30s 默认超时远短于其平均响应窗口。

**（三）alert 风暴延迟** — `all_categories` alert_mask，330 个 tracker 每轮 announce 产生 2000+ 条高频 alert，Python 层逐条处理 + 日志 I/O 导致队列积压。**实测 GUI：元数据 19:34:01 已下载，但 `metadata_received_alert` 处理延迟至 19:34:37，`wait_for` 在 19:34:36 先行超时**。

### 修复（4 commits）

| Commit | 文件 | 要点 |
|---|---|---|
| 7a379ea | config/session/schema | 超时 30→120s；默认源加 all.txt；UPnP/NAT-PMP；代理映射支持 http/https/socks4 |
| e83fe64 | session | 显式 4 个 DHT bootstrap 节点（router.bittorrent.com 等，对齐 qBittorrent） |
| a308ceb | pack | `activate()` 中预热 session，app 启动时 DHT 即开始 bootstrap |
| 3c03b42 | session | alert_mask 精选 `error|port_mapping|storage|status`（77），`_routeAlert` 按类型分流 |

### 验证

| 条件 | 修复前 | 修复后 |
|---|---|---|
| 脚本 fetchMetadata（330 tracker + 预热） | 60~150s 超时 | **2.9~4.0s** |
| GUI 实测（命令行触发） | 30~120s 超时 | 秒级弹出种子名 + 542.98 MB |
| 下载速度（脚本实测） | — | 平均 4.54 MiB/s，峰值 16.28 MiB/s（与 qBittorrent 持平） |
| 无额外 tracker | 0 peers / 0 速度 | — |

pytest：`test_bt_session` 7 passed、`test_proxy_settings` 10 passed；全量 238 passed（9 errors 为预存在的 `test_task_page` fixture 问题，无关）。

### 兼容

- 配置默认值变化（MetadataTimeout 30→120、WebTrackerSources 加 all.txt）仅对新安装生效，已有配置不受影响
- BT 任务模型/序列化/resume 格式未改动，历史任务恢复不受影响
- 不涉及浏览器扩展
