### PR TITLE
fix: replace Bilibili segment file on Windows

### DIFF
--- a/features/bili_pack/task.py
+++ b/features/bili_pack/task.py
@@ -377,9 +377,6 @@ class BilibiliMergeStep(FFmpegStep):
                     f.write(header)
                     with open(path, "rb") as seg:
                         shutil.copyfileobj(seg, f)
-                # Path.rename cannot replace an existing file on Windows.
-                # The segment download already created the target, so use
-                # replace semantics when installing the patched header.
                 tmp.replace(path)
 
         hasVideo = self._videoPath.exists()

--- a/features/bili_pack/task.py
+++ b/features/bili_pack/task.py
@@ -377,7 +377,10 @@ class BilibiliMergeStep(FFmpegStep):
                     f.write(header)
                     with open(path, "rb") as seg:
                         shutil.copyfileobj(seg, f)
-                tmp.rename(path)
+                # Path.rename cannot replace an existing file on Windows.
+                # The segment download already created the target, so use
+                # replace semantics when installing the patched header.
+                tmp.replace(path)
 
         hasVideo = self._videoPath.exists()
         hasAudio = self._audioPath.exists()

--- a/features/yt_dlp_pack/task.py
+++ b/features/yt_dlp_pack/task.py
@@ -594,7 +594,7 @@ class YouTubeMergeStep(FFmpegStep):
                     f.write(header)
                     with open(path, "rb") as seg:
                         shutil.copyfileobj(seg, f)
-                tmp.rename(path)
+                tmp.replace(path)
 
         hasVideo = self._videoPath.exists()
         hasAudio = self._audioPath.exists()


### PR DESCRIPTION
## PR Description
Fixes #743.

When downloading a selected Bilibili time range on Windows, the merge step prepends the patched MP4 header to the partially downloaded `.video.m4s` file. `Path.rename()` cannot replace an existing destination on Windows, so the task failed with `WinError 183` even though the segment download succeeded. Use `Path.replace()` so the temporary patched file atomically replaces the existing target on every supported platform.

## PR Type

- [x] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor (no functional changes, no API updates)
- [ ] Build or CI update
- [ ] Other (please describe in PR description)

## AI Tool Usage

- [x] AI tool(s) assisted part of the development of this PR (e.g. code completion, looking up usage)
- [ ] AI tool(s) primarily generated code in this PR (please specify tool and model, e.g. `Cursor + Claude Sonnet 4`)

## PR Checklist

- [ ] Tested locally, app starts successfully and works as expected (PySide6/runtime dependencies are not installed in this environment; compile validation was run instead)
- [x] This PR does **not** include breaking changes

## Notes

Validation performed:
- `python -m compileall -q features/bili_pack/task.py`
- `git diff --check`

The issue log shows the failure at `features/bili_pack/task.py:380` with `FileExistsError: [WinError 183]` while renaming `.video.tmp` over the existing `.video.m4s` path.