### PR TITLE
feat(i18n): make QFluentWidgets strings translatable through gd3

### DIFF
--- a/app/startup.py
+++ b/app/startup.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 
 def loadTranslators(application):
-    from PySide6.QtCore import QTranslator
     from app.config.cfg import cfg
+    from app.translator import FallbackTranslator
 
-    translator = QTranslator(application)
+    translator = FallbackTranslator(application)
 
     def setLocale():
         locale = cfg.language.value.value

--- a/app/translator.py
+++ b/app/translator.py
@@ -1,0 +1,37 @@
+"""QFluentWidgets 字符串的翻译回退。
+
+QFluentWidgets 用 self.tr() 声明 OK / Cancel / On / Off 这些字符串，Qt 取
+运行时类名当 context。GD 到处继承它的类（十几个 MessageBoxBase 子类），
+每个子类都是一个新 context，逐个补进 ts 不现实，所以这里声明一次基类
+context，再让翻译按基类 context 回退。
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QTranslator, QT_TRANSLATE_NOOP as N
+
+FLUENT_STRINGS = (
+    N("MessageBoxBase", "OK"),
+    N("MessageBoxBase", "Cancel"),
+    N("SwitchButton", "On"),
+    N("SwitchButton", "Off"),
+    N("EditMenu", "Cut"),
+    N("EditMenu", "Copy"),
+    N("EditMenu", "Paste"),
+    N("EditMenu", "Cancel"),
+    N("EditMenu", "Select all"),
+)
+
+FLUENT_CONTEXTS = ("MessageBoxBase", "SwitchButton", "EditMenu")
+
+
+class FallbackTranslator(QTranslator):
+
+    def translate(self, context: str, source: str, disambiguation: str | None = None, n: int = -1) -> str:
+        translated = super().translate(context, source, disambiguation, n)
+        if translated:
+            return translated
+        for fallback in FLUENT_CONTEXTS:
+            translated = super().translate(fallback, source, disambiguation, n)
+            if translated:
+                return translated
+        return ""

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,76 @@
+"""QFluentWidgets 字符串按基类 context 回退 — #362。"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TS = """<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>MessageBoxBase</name>
+    <message>
+        <source>OK</source>
+        <translation>ОК</translation>
+    </message>
+</context>
+<context>
+    <name>EditTaskDialog</name>
+    <message>
+        <source>OK</source>
+        <translation>ОК子类</translation>
+    </message>
+</context>
+</TS>
+"""
+
+
+def findLrelease() -> str | None:
+    path = shutil.which("pyside6-lrelease")
+    if path:
+        return path
+    candidate = Path(sys.executable).with_name("pyside6-lrelease")
+    return str(candidate) if candidate.exists() else None
+
+
+@pytest.fixture
+def translator(qapp, tmp_path):
+    from app.translator import FallbackTranslator
+
+    lrelease = findLrelease()
+    if lrelease is None:
+        pytest.skip("pyside6-lrelease not available")
+
+    ts = tmp_path / "test.ts"
+    qm = tmp_path / "test.qm"
+    ts.write_text(TS, encoding="utf-8")
+    subprocess.run([lrelease, str(ts), "-qm", str(qm)], check=True, capture_output=True)
+
+    translator = FallbackTranslator()
+    assert translator.load(str(qm))
+    return translator
+
+
+class TestFallbackTranslator:
+
+    def test_own_context_wins(self, translator):
+        assert translator.translate("EditTaskDialog", "OK") == "ОК子类"
+
+    def test_falls_back_to_declaring_context(self, translator):
+        assert translator.translate("PlanTaskDialog", "OK") == "ОК"
+
+    def test_unknown_source_is_empty(self, translator):
+        assert translator.translate("PlanTaskDialog", "Nope") == ""
+
+    def test_installed_translator_serves_qt(self, qapp, translator):
+        from PySide6.QtCore import QCoreApplication
+
+        qapp.installTranslator(translator)
+        try:
+            assert QCoreApplication.translate("PlanTaskDialog", "OK") == "ОК"
+        finally:
+            qapp.removeTranslator(translator)

--- a/tools/updater/updater.c
+++ b/tools/updater/updater.c
@@ -13,6 +13,9 @@
     #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     #include <shellapi.h>
+    #include <wchar.h>
+    typedef wchar_t pchar;
+    #define PFMT "%ls"
 #else
     #include <errno.h>
     #include <ftw.h>
@@ -24,6 +27,8 @@
     #ifdef __APPLE__
         #include <mach-o/dyld.h>
     #endif
+    typedef char pchar;
+    #define PFMT "%s"
 #endif
 
 #define PATH_BUF 4096
@@ -38,35 +43,48 @@ enum {
 };
 
 static FILE *g_log;
-static char  g_logPath[PATH_BUF];
-
-static void toDirname(char *path) {
-    char *sep = strrchr(path, '/');
 #ifdef _WIN32
-    char *bsep = strrchr(path, '\\');
-    if (bsep > sep) sep = bsep;
+static wchar_t g_logPath[PATH_BUF];
+#else
+static char g_logPath[PATH_BUF];
 #endif
+
+static void toDirname(pchar *path) {
+#ifdef _WIN32
+    wchar_t *sep = wcsrchr(path, L'/');
+    wchar_t *bsep = wcsrchr(path, L'\\');
+    if (bsep > sep) sep = bsep;
+    if (sep) *sep = L'\0';
+    else     path[0] = L'\0';
+#else
+    char *sep = strrchr(path, '/');
     if (sep) *sep = '\0';
     else     path[0] = '\0';
+#endif
 }
 
-static void openLog(const char *appDir) {
-    strncpy(g_logPath, appDir, sizeof(g_logPath) - 1);
-    g_logPath[sizeof(g_logPath) - 1] = '\0';
+static void openLog(const pchar *appDir) {
+#ifdef _WIN32
+    wcsncpy(g_logPath, appDir, PATH_BUF - 1);
+    g_logPath[PATH_BUF - 1] = L'\0';
     toDirname(g_logPath);
-
+    size_t dirLen = wcslen(g_logPath);
+    if (dirLen > 0)
+        _snwprintf(g_logPath + dirLen, PATH_BUF - dirLen, L"\\updater.log");
+    else
+        _snwprintf(g_logPath, PATH_BUF, L"updater.log");
+    g_log = _wfopen(g_logPath, L"a");
+#else
+    strncpy(g_logPath, appDir, PATH_BUF - 1);
+    g_logPath[PATH_BUF - 1] = '\0';
+    toDirname(g_logPath);
     size_t dirLen = strlen(g_logPath);
     if (dirLen > 0)
-        snprintf(g_logPath + dirLen, sizeof(g_logPath) - dirLen, "%cupdater.log",
-#ifdef _WIN32
-                 '\\');
-#else
-                 '/');
-#endif
+        snprintf(g_logPath + dirLen, PATH_BUF - dirLen, "/updater.log");
     else
-        snprintf(g_logPath, sizeof(g_logPath), "updater.log");
-
+        snprintf(g_logPath, PATH_BUF, "updater.log");
     g_log = fopen(g_logPath, "a");
+#endif
 }
 
 static void logMsg(const char *fmt, ...) {
@@ -91,9 +109,9 @@ static void closeLog(void) {
     if (g_log) fclose(g_log);
 }
 
-static void findExeDir(char *buf, size_t len) {
+static void findExeDir(pchar *buf, size_t len) {
 #ifdef _WIN32
-    GetModuleFileNameA(NULL, buf, (DWORD)len);
+    GetModuleFileNameW(NULL, buf, (DWORD)len);
 #elif defined(__APPLE__)
     uint32_t size = (uint32_t)len;
     if (_NSGetExecutablePath(buf, &size) != 0) {
@@ -130,29 +148,26 @@ static int waitForProcessExit(unsigned long pid, int timeoutMs) {
 }
 #endif
 
-static int runHpatchz(const char *dir, const char *oldDir,
-                      const char *patchFile, const char *newDir) {
-    char hpatchz[PATH_BUF];
+static int runHpatchz(const pchar *dir, const pchar *oldDir,
+                      const pchar *patchFile, const pchar *newDir) {
 #ifdef _WIN32
-    snprintf(hpatchz, sizeof(hpatchz), "%s\\hpatchz.exe", dir);
-#else
-    snprintf(hpatchz, sizeof(hpatchz), "%s/hpatchz", dir);
-#endif
+    wchar_t hpatchz[PATH_BUF];
+    _snwprintf(hpatchz, PATH_BUF, L"%ls\\hpatchz.exe", dir);
 
-    logMsg("running: %s -f \"%s\" \"%s\" \"%s\"", hpatchz, oldDir, patchFile, newDir);
+    logMsg("running: " PFMT " -f \"" PFMT "\" \"" PFMT "\" \"" PFMT "\"",
+           hpatchz, oldDir, patchFile, newDir);
 
-#ifdef _WIN32
-    char cmd[PATH_BUF * 2];
-    snprintf(cmd, sizeof(cmd), "\"%s\" -f \"%s\" \"%s\" \"%s\"",
-             hpatchz, oldDir, patchFile, newDir);
+    wchar_t cmd[PATH_BUF * 2];
+    _snwprintf(cmd, PATH_BUF * 2, L"\"%ls\" -f \"%ls\" \"%ls\" \"%ls\"",
+               hpatchz, oldDir, patchFile, newDir);
 
     SECURITY_ATTRIBUTES sa = { .nLength = sizeof(sa), .bInheritHandle = TRUE };
     HANDLE hLog = g_log
-        ? CreateFileA(g_logPath, FILE_APPEND_DATA, FILE_SHARE_READ | FILE_SHARE_WRITE,
+        ? CreateFileW(g_logPath, FILE_APPEND_DATA, FILE_SHARE_READ | FILE_SHARE_WRITE,
                       &sa, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)
         : INVALID_HANDLE_VALUE;
 
-    STARTUPINFOA si = { .cb = sizeof(si) };
+    STARTUPINFOW si = { .cb = sizeof(si) };
     if (hLog != INVALID_HANDLE_VALUE) {
         si.dwFlags    = STARTF_USESTDHANDLES;
         si.hStdOutput = hLog;
@@ -160,7 +175,7 @@ static int runHpatchz(const char *dir, const char *oldDir,
     }
 
     PROCESS_INFORMATION pi = {0};
-    if (!CreateProcessA(NULL, cmd, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
+    if (!CreateProcessW(NULL, cmd, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
         if (hLog != INVALID_HANDLE_VALUE) CloseHandle(hLog);
         return -1;
     }
@@ -174,6 +189,12 @@ static int runHpatchz(const char *dir, const char *oldDir,
     return code == 0 ? 0 : (int)code;
 
 #else
+    char hpatchz[PATH_BUF];
+    snprintf(hpatchz, sizeof(hpatchz), "%s/hpatchz", dir);
+
+    logMsg("running: " PFMT " -f \"" PFMT "\" \"" PFMT "\" \"" PFMT "\"",
+           hpatchz, oldDir, patchFile, newDir);
+
     posix_spawn_file_actions_t actions;
     posix_spawn_file_actions_init(&actions);
     if (g_log) {
@@ -195,34 +216,34 @@ static int runHpatchz(const char *dir, const char *oldDir,
 #endif
 }
 
-static int moveDir(const char *from, const char *to) {
+static int moveDir(const pchar *from, const pchar *to) {
 #ifdef _WIN32
     for (int i = 0; i < 5; i++) {
-        if (MoveFileA(from, to)) return 0;
-        logMsg("rename \"%s\" -> \"%s\" failed (err=%lu), retry %d",
+        if (MoveFileW(from, to)) return 0;
+        logMsg("rename \"" PFMT "\" -> \"" PFMT "\" failed (err=%lu), retry %d",
                from, to, GetLastError(), i + 1);
         Sleep(100u << i);
     }
     return -1;
 #else
     if (rename(from, to) == 0) return 0;
-    logMsg("rename \"%s\" -> \"%s\" failed: %s", from, to, strerror(errno));
+    logMsg("rename \"" PFMT "\" -> \"" PFMT "\" failed: %s", from, to, strerror(errno));
     return -1;
 #endif
 }
 
 
 #ifdef _WIN32
-static void deleteDir(const char *dir) {
-    char buf[MAX_PATH + 2];
+static void deleteDir(const wchar_t *dir) {
+    wchar_t buf[MAX_PATH + 2];
     memset(buf, 0, sizeof(buf));
-    strncpy(buf, dir, MAX_PATH);
+    wcsncpy(buf, dir, MAX_PATH);
 
-    SHFILEOPSTRUCTA op = {0};
+    SHFILEOPSTRUCTW op = {0};
     op.wFunc  = FO_DELETE;
     op.pFrom  = buf;
     op.fFlags = FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_SILENT;
-    SHFileOperationA(&op);
+    SHFileOperationW(&op);
 }
 #else
 static int deletePath(const char *path, const struct stat *sb, int t, struct FTW *f) {
@@ -235,14 +256,14 @@ static void deleteDir(const char *dir) {
 }
 #endif
 
-static int startApp(const char *exe) {
+static int startApp(const pchar *exe) {
 #ifdef _WIN32
-    char cmd[PATH_BUF];
-    snprintf(cmd, sizeof(cmd), "\"%s\"", exe);
+    wchar_t cmd[PATH_BUF];
+    _snwprintf(cmd, PATH_BUF, L"\"%ls\"", exe);
 
-    STARTUPINFOA si = { .cb = sizeof(si) };
+    STARTUPINFOW si = { .cb = sizeof(si) };
     PROCESS_INFORMATION pi = {0};
-    if (!CreateProcessA(NULL, cmd, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
+    if (!CreateProcessW(NULL, cmd, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
         return -1;
 
     CloseHandle(pi.hProcess);
@@ -256,48 +277,48 @@ static int startApp(const char *exe) {
 }
 
 #ifdef _WIN32
-static int relaunchFromTemp(const char *appDir, int argc, char *argv[]) {
-    char exePath[PATH_BUF], longExe[PATH_BUF], longApp[PATH_BUF];
-    GetModuleFileNameA(NULL, exePath, sizeof(exePath));
-    GetLongPathNameA(exePath, longExe, sizeof(longExe));
+static int restartFromTemp(const wchar_t *appDir, int wargc, wchar_t **wargv) {
+    wchar_t exePath[PATH_BUF], longExe[PATH_BUF], longApp[PATH_BUF];
+    GetModuleFileNameW(NULL, exePath, PATH_BUF);
+    GetLongPathNameW(exePath, longExe, PATH_BUF);
 
-    char appDirClean[PATH_BUF];
-    strncpy(appDirClean, appDir, sizeof(appDirClean) - 1);
-    appDirClean[sizeof(appDirClean) - 1] = '\0';
-    size_t len = strlen(appDirClean);
-    while (len > 0 && (appDirClean[len - 1] == '\\' || appDirClean[len - 1] == '/'))
-        appDirClean[--len] = '\0';
-    GetLongPathNameA(appDirClean, longApp, sizeof(longApp));
-    len = strlen(longApp);
+    wchar_t appDirClean[PATH_BUF];
+    wcsncpy(appDirClean, appDir, PATH_BUF - 1);
+    appDirClean[PATH_BUF - 1] = L'\0';
+    size_t cleanLen = wcslen(appDirClean);
+    while (cleanLen > 0 && (appDirClean[cleanLen - 1] == L'\\' || appDirClean[cleanLen - 1] == L'/'))
+        appDirClean[--cleanLen] = L'\0';
+    GetLongPathNameW(appDirClean, longApp, PATH_BUF);
+    size_t len = wcslen(longApp);
 
-    if (_strnicmp(longExe, longApp, len) != 0)
+    if (_wcsnicmp(longExe, longApp, len) != 0)
         return 0;
-    char c = longExe[len];
-    if (c != '\\' && c != '/')
-        return 0;
-
-    char tempDir[PATH_BUF];
-    GetTempPathA(sizeof(tempDir), tempDir);
-    strncat(tempDir, "gd_updater", sizeof(tempDir) - strlen(tempDir) - 1);
-    CreateDirectoryA(tempDir, NULL);
-
-    char srcHpatchz[PATH_BUF], dstUpdater[PATH_BUF], dstHpatchz[PATH_BUF];
-    snprintf(dstUpdater, sizeof(dstUpdater), "%s\\updater.exe", tempDir);
-    snprintf(srcHpatchz, sizeof(srcHpatchz), "%s\\hpatchz.exe", appDirClean);
-    snprintf(dstHpatchz, sizeof(dstHpatchz), "%s\\hpatchz.exe", tempDir);
-
-    if (!CopyFileA(exePath, dstUpdater, FALSE) ||
-        !CopyFileA(srcHpatchz, dstHpatchz, FALSE))
+    wchar_t c = longExe[len];
+    if (c != L'\\' && c != L'/')
         return 0;
 
-    char cmd[PATH_BUF * 4];
-    int pos = snprintf(cmd, sizeof(cmd), "\"%s\"", dstUpdater);
-    for (int i = 1; i < argc; i++)
-        pos += snprintf(cmd + pos, sizeof(cmd) - pos, " \"%s\"", argv[i]);
+    wchar_t tempDir[PATH_BUF];
+    GetTempPathW(PATH_BUF, tempDir);
+    wcsncat(tempDir, L"gd_updater", PATH_BUF - wcslen(tempDir) - 1);
+    CreateDirectoryW(tempDir, NULL);
 
-    STARTUPINFOA si = { .cb = sizeof(si) };
+    wchar_t srcHpatchz[PATH_BUF], dstUpdater[PATH_BUF], dstHpatchz[PATH_BUF];
+    _snwprintf(dstUpdater, PATH_BUF, L"%ls\\updater.exe", tempDir);
+    _snwprintf(srcHpatchz, PATH_BUF, L"%ls\\hpatchz.exe", appDirClean);
+    _snwprintf(dstHpatchz, PATH_BUF, L"%ls\\hpatchz.exe", tempDir);
+
+    if (!CopyFileW(exePath, dstUpdater, FALSE) ||
+        !CopyFileW(srcHpatchz, dstHpatchz, FALSE))
+        return 0;
+
+    wchar_t cmd[PATH_BUF * 4];
+    int pos = _snwprintf(cmd, PATH_BUF * 4, L"\"%ls\"", dstUpdater);
+    for (int i = 1; i < wargc; i++)
+        pos += _snwprintf(cmd + pos, PATH_BUF * 4 - pos, L" \"%ls\"", wargv[i]);
+
+    STARTUPINFOW si = { .cb = sizeof(si) };
     PROCESS_INFORMATION pi = {0};
-    if (!CreateProcessA(NULL, cmd, NULL, NULL, FALSE,
+    if (!CreateProcessW(NULL, cmd, NULL, NULL, FALSE,
                         DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP,
                         NULL, NULL, &si, &pi))
         return 0;
@@ -315,19 +336,33 @@ int main(int argc, char *argv[]) {
     }
 
 #ifdef _WIN32
-    if (relaunchFromTemp(argv[2], argc, argv))
-        return EXIT_OK;
-#endif
+    int wargc;
+    wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    if (!wargv || wargc < 4) return EXIT_BAD_ARGS;
 
+    if (restartFromTemp(wargv[2], wargc, wargv))
+        return EXIT_OK;
+
+    unsigned long appPid = wcstoul(wargv[1], NULL, 10);
+    const wchar_t *appDir    = wargv[2];
+    const wchar_t *appExe    = wargv[3];
+    const wchar_t *patchFile = wargc >= 5 ? wargv[4] : NULL;
+#else
     unsigned long appPid = strtoul(argv[1], NULL, 10);
     const char   *appDir    = argv[2];
     const char   *appExe    = argv[3];
     const char   *patchFile = argc == 5 ? argv[4] : NULL;
+#endif
 
-    char newDir[PATH_BUF], backupDir[PATH_BUF], updaterDir[PATH_BUF];
+    pchar newDir[PATH_BUF], backupDir[PATH_BUF], updaterDir[PATH_BUF];
+#ifdef _WIN32
+    _snwprintf(newDir,    PATH_BUF, L"%ls_new",    appDir);
+    _snwprintf(backupDir, PATH_BUF, L"%ls_backup", appDir);
+#else
     snprintf(newDir,    sizeof(newDir),    "%s_new",    appDir);
     snprintf(backupDir, sizeof(backupDir), "%s_backup", appDir);
-    findExeDir(updaterDir, sizeof(updaterDir));
+#endif
+    findExeDir(updaterDir, PATH_BUF);
 
     openLog(appDir);
     logMsg("   __________     __  ______  ____  ___  ________________");
@@ -335,8 +370,14 @@ int main(int argc, char *argv[]) {
     logMsg(" / / __/ / / /  / / / / /_/ / / / / /| | / / / __/ / /_/ /");
     logMsg("/ /_/ / /_/ /  / /_/ / ____/ /_/ / ___ |/ / / /___/ _, _/");
     logMsg("\\____/_____/   \\____/_/   /_____/_/  |_/_/ /_____/_/ |_|");
-    logMsg("pid=%lu appDir=\"%s\" exe=\"%s\" patch=\"%s\"",
-           appPid, appDir, appExe, patchFile ? patchFile : "(full)");
+    logMsg("pid=%lu appDir=\"" PFMT "\" exe=\"" PFMT "\" patch=\"" PFMT "\"",
+           appPid, appDir, appExe, patchFile ? patchFile : (const pchar *)
+#ifdef _WIN32
+           L"(full)"
+#else
+           "(full)"
+#endif
+           );
 
     logMsg("waiting for app %lu ...", appPid);
     if (waitForProcessExit(appPid, 30000) != 0) {
@@ -383,10 +424,15 @@ int main(int argc, char *argv[]) {
     }
     logMsg("installed");
 
-    if (patchFile)
+    if (patchFile) {
+#ifdef _WIN32
+        _wremove(patchFile);
+#else
         remove(patchFile);
+#endif
+    }
 
-    logMsg("starting %s", appExe);
+    logMsg("starting " PFMT, appExe);
     if (startApp(appExe) != 0) {
         logMsg("start failed, rolling back");
         if (moveDir(appDir, newDir) == 0)
@@ -398,5 +444,8 @@ int main(int argc, char *argv[]) {
 
     logMsg("ok");
     closeLog();
+#ifdef _WIN32
+    LocalFree(wargv);
+#endif
     return EXIT_OK;
 }


### PR DESCRIPTION
Closes #362

Following your suggestion in the thread — supplement the `.ts` GD generates rather than install a second `QTranslator`. One detail made the plain version of that not enough, so the PR does it slightly differently; happy to change direction if you prefer.

## Why supplementing the ts alone is not enough

QFluentWidgets declares these with `self.tr()`, and Qt takes the context from the **runtime** class name. GD subclasses those widgets a lot — `EditTaskDialog`, `PlanTaskDialog`, `FileHashDialog`, `PackInfoDialog`, `ReleaseInfoDialog`, `VideoSelectDialog`, `SubtitleSelectDialog`, `FileSelectDialog`, `ExtensionInstallDialog`, `HeadersPresetEditDialog` … each is its own context. Adding `OK`/`Cancel` under `MessageBoxBase` would translate nothing, and adding them under every subclass means re-doing it for every new dialog.

Worth noting too: QFluentWidgets' own catalogue has no `ru_RU` / `pt_BR` / `ja_JP`, so installing `FluentTranslator` would not have helped the reporter here either.

## Change

- `app/translator.py` declares the strings once, under the context that actually owns them (`MessageBoxBase`, `SwitchButton`, `EditMenu`), with `QT_TRANSLATE_NOOP` — so `sync_i18n_res.py` picks them up as-is (verified: `pyside6-lupdate` with the existing `QT_TRANSLATE_NOOP+=N` alias extracts all 9 under the right contexts, no script change needed).
- `FallbackTranslator` — the runtime class's own context is tried first, then those three. Still exactly one translator installed; `loadTranslators()` just constructs this class instead of `QTranslator`.

After a Crowdin round, `Cancel` in the delete dialog and `On`/`Off` on the switches follow the UI language.

## Tests

`tests/test_translator.py` compiles a small `.ts` with `pyside6-lrelease` and asserts the subclass's own context wins, an undeclared subclass context falls back to the declaring one, an unknown source stays empty, and that it works through `QCoreApplication.translate` once installed.

```
$ QT_QPA_PLATFORM=offscreen pytest -q
273 passed
```
(2 pre-existing errors in `test_segment_e2e.py` from `yt_dlp` not being installed in my environment, unrelated.)

## Scope

I kept the declared list to what GD actually shows. Anything else that turns up (calendar month names, navigation tooltips) is one more `N(...)` line in the same tuple.