### PR TITLE
fix(filesystem): 忽略格式非法的 file:// URL，避免剪贴板监听崩溃

### DIFF
--- a/app/platform/filesystem.py
+++ b/app/platform/filesystem.py
@@ -74,7 +74,10 @@ def localFilePath(url: str, validSuffixes: set[str] | None = None) -> Path | Non
         else:
             return None
 
-    path = Path(url2pathname(rawPath))
+    try:
+        path = Path(url2pathname(rawPath))
+    except OSError:
+        return None
     if not path.is_file():
         return None
     if validSuffixes is not None and path.suffix.lower() not in validSuffixes:


### PR DESCRIPTION
## PR 描述

被动剪贴板监听会把每一行能通过 urlparse 往返解析的文本交给
FeatureService.matchPassive。当剪贴板里出现终端/编辑器堆栈，例如

    file:///C:/Users/Petal/AppData/Roaming/npm/.../index.js:1186

时，m3u8 解析器的 match 会调用 localFilePath()，把
/C:/.../index.js:1186 传给 url2pathname()。Windows 上
nturl2path.url2pathname 会把所有 : 替换为 |，由于结果里有两段 |
（盘符和行号），抛出 OSError: Bad URL: /C|/.../index.js|1186。
该异常没有被剪贴板回调捕获，导致弹出全局错误对话框。

本 PR 在 localFilePath() 中用 try/except OSError 包住
url2pathname() 调用并返回 None，非法 file:// URL 会被直接忽略，
行为与普通不存在/非清单文件一致。

## PR 类型

- [x] Bug 修复
- [ ] 功能
- [ ] 代码样式更新
- [ ] 重构（没有功能修改，没有 API 更新）
- [ ] Build 或 CI 更新
- [ ] 其他（请在 PR 描述中说明）

## AI 工具使用

- [ ] AI 工具辅助了本 PR 的部分开发（如代码补全、查阅用法等）
- [x] AI 工具主要生成了本 PR 中的代码
DeepSeek Harness + DeepSeek V4 Pro

## PR 检查清单

- [x] 已在本地测试，应用成功启动且功能正常
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

-  `localFilePath()` 中的 `url2pathname()` 调用增加 `try/except OSError` 守卫，非法 `file://` URL 返回 `None`，行为与普通不存在/非清单文件一致。