### PR TITLE
feat(launch): 浏览器扩展静默唤起下载器

### DIFF
--- a/app/platform/url_scheme.py
+++ b/app/platform/url_scheme.py
@@ -37,7 +37,7 @@ if sys.platform == "win32":
 
     def _registerWindows(scheme: str) -> None:
         regRoot = rf"Software\Classes\{scheme}"
-        command = f'"{QCoreApplication.applicationFilePath().replace("/", chr(92))}" "%1"'
+        command = f'"{QCoreApplication.applicationFilePath().replace("/", chr(92))}" --silence "%1"'
         with winreg.CreateKey(winreg.HKEY_CURRENT_USER, regRoot) as key:
             winreg.SetValueEx(key, "", 0, winreg.REG_SZ, f"Ghost Downloader URL ({scheme})")
             winreg.SetValueEx(key, "URL Protocol", 0, winreg.REG_SZ, "")
@@ -80,7 +80,7 @@ if sys.platform == "linux":
                 "[Desktop Entry]\n"
                 "Type=Application\n"
                 "Name=Ghost Downloader\n"
-                f"Exec={appPath} %U\n"
+                f"Exec={appPath} --silence %U\n"
                 "Icon=ghost-downloader\n"
                 "Terminal=false\n"
                 "Categories=Network;Utility;\n"


### PR DESCRIPTION
## PR 描述
当浏览器扩展程序通过自定义 URL Scheme 唤起 Ghost Downloader 3 主程序时，自动传递 `--silence` 参数，使主程序在后台（系统托盘）静默启动并接管下载任务，不再自动弹出主窗口，实现无干扰的下载体验。

Closes #xxx （如有对应 Issue 请填写）

## PR 类型

- [ ] Bug 修复
- [x] 功能
- [ ] 代码样式更新
- [ ] 重构（没有功能修改，没有 API 更新）
- [ ] Build 或 CI 更新
- [ ] 其他（请在 PR 描述中说明）

## AI 工具使用

- [ ] AI 工具辅助了本 PR 的部分开发（如代码补全、查阅用法等）
- [x] AI 工具主要生成了本 PR 中的代码（请注明工具与模型，如 `Cursor + Claude Sonnet 4`）

详见 [AI 工具使用政策](CONTRIBUTING.md#ai-工具使用政策)。

## PR 检查清单

- [x] 已在本地测试，应用成功启动且功能正常
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

### 修改方案
| 文件 | 行号 | 修改内容 |
|------|------|----------|
| `app/platform/url_scheme.py` | 第 40 行 | 注册命令添加 `--silence` 参数 |

**修改前：**
```python
command = f'"{QCoreApplication.applicationFilePath().replace("/", chr(92))}" "%1"'
```

**修改后：**
```python
command = f'"{QCoreApplication.applicationFilePath().replace("/", chr(92))}" --silence "%1"'
```

### 行为说明
- **触发场景**：用户在浏览器中点击下载链接，被 Ghost Downloader 3 浏览器插件拦截。
- **软件响应**：Ghost Downloader 3 主程序启动（如果尚未运行）并接收下载任务。
- **界面表现**：整个过程**不弹出、不激活** Ghost Downloader 3 的主窗口。软件仅在系统托盘（Tray）或后台进程中运行，任务开始下载后可通过托盘图标或快捷键唤出主界面进行管理。