### PR TITLE
fix: add configurable per-site download compatibility rules

### DIFF
--- a/app/config/cfg.py
+++ b/app/config/cfg.py
@@ -142,6 +142,17 @@ class CategoryListValidator(ConfigValidator):
         return value if self.validate(value) else []
 
 
+class SiteRuleListValidator(ConfigValidator):
+    def validate(self, value) -> bool:
+        from app.site_rules import validateSiteRule
+        return isinstance(value, list) and bool(value) and all(validateSiteRule(item) for item in value)
+
+    def correct(self, value) -> list:
+        from app.site_rules import defaultSiteRules, validateSiteRule
+        rules = [item for item in value if validateSiteRule(item)] if isinstance(value, list) else []
+        return rules or defaultSiteRules()
+
+
 class JsonConfigSerializer(ConfigSerializer):
     def __init__(self, expected: type, fallback):
         self._expected = expected
@@ -254,6 +265,13 @@ class Config(QConfig):
     categoryRules = ConfigItem(
         "Category", "CategoryRules", [],
         CategoryListValidator(), JsonConfigSerializer(list, list),
+    )
+
+    # Site-specific compatibility rules, editable without rebuilding the app.
+    from app.site_rules import defaultSiteRules
+    siteRules = ConfigItem(
+        "SiteRules", "Rules", defaultSiteRules(),
+        SiteRuleListValidator(), JsonConfigSerializer(list, defaultSiteRules),
     )
 
     # 浏览器扩展

--- a/app/services/browser_service.py
+++ b/app/services/browser_service.py
@@ -19,6 +19,7 @@ from loguru import logger
 from app.config.cfg import cfg
 from app.config.constants import LATEST_EXTENSION_VERSION, VERSION
 from app.config.paths import APP_DATA_DIR
+from app.site_rules import publicSiteRules
 
 from app.models.task import MergeTaskOptions, PageTaskOptions
 
@@ -70,6 +71,7 @@ class MessageType(StrEnum):
     TASK_ACTION = "task_action"
     TASK_ACTION_RESULT = "task_action_result"
     RELOAD = "reload"
+    SITE_RULES = "site_rules"
 
 
 class ErrorCode(StrEnum):
@@ -438,6 +440,7 @@ class BrowserService(QObject):
                 "taskSnapshots": True,
                 "taskActions": [a.value for a in TaskAction],
             },
+            "siteRules": publicSiteRules(cfg.siteRules.value),
         })
 
         if (session.installType == "development"
@@ -451,6 +454,15 @@ class BrowserService(QObject):
                 failed=self._onExtensionExtractFailed,
                 session=session,
             )
+
+    def broadcastSiteRules(self) -> None:
+        payload = {
+            "type": MessageType.SITE_RULES,
+            "rules": publicSiteRules(cfg.siteRules.value),
+        }
+        for session in list(self._sessions.values()):
+            if session.isAuthenticated:
+                self._send(session, payload)
 
     def _onExtensionExtracted(self, _path: Path, session: BrowserClientSession) -> None:
         if id(session.socket) not in self._sessions:

--- a/app/site_rules.py
+++ b/app/site_rules.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from fnmatch import fnmatch
+from urllib.parse import urlparse
+
+
+DEFAULT_SITE_RULES = [
+    {
+        "id": "pixeldrain",
+        "name": "PixelDrain",
+        "hosts": ["pixeldrain.com", "*.pixeldrain.com"],
+        "action": "pixeldrain_api",
+        "enabled": True,
+        "connections": 1,
+        "description": "Uses the file API, correct Referer and one stable connection.",
+    },
+    {
+        "id": "uupdump",
+        "name": "UUP dump",
+        "hosts": ["uupdump.net", "*.uupdump.net"],
+        "action": "uupdump_post",
+        "enabled": True,
+        "connections": 1,
+        "description": "Submits the required form and rejects HTML returned instead of ZIP data.",
+    },
+    {
+        "id": "hdsex",
+        "name": "HDSex",
+        "hosts": ["hdsex.org", "*.hdsex.org"],
+        "action": "prefer_latest_hls",
+        "enabled": True,
+        "connections": 1,
+        "description": "Prefers the player's newest HLS manifest, skipping an earlier pre-roll stream.",
+    },
+]
+
+SITE_RULE_ACTIONS = {
+    "standard",
+    "single_connection",
+    "pixeldrain_api",
+    "uupdump_post",
+    "prefer_latest_hls",
+}
+
+
+def defaultSiteRules() -> list[dict]:
+    return deepcopy(DEFAULT_SITE_RULES)
+
+
+def normalizeHost(host: str) -> str:
+    value = host.strip().lower()
+    if "://" in value:
+        value = (urlparse(value).hostname or "").lower()
+    return value.strip("./")
+
+
+def validateSiteRule(rule: object) -> bool:
+    if not isinstance(rule, dict):
+        return False
+    hosts = rule.get("hosts")
+    return (
+        isinstance(rule.get("id"), str)
+        and bool(rule["id"].strip())
+        and isinstance(rule.get("name"), str)
+        and bool(rule["name"].strip())
+        and isinstance(hosts, list)
+        and bool(hosts)
+        and all(isinstance(host, str) and bool(normalizeHost(host)) for host in hosts)
+        and rule.get("action") in SITE_RULE_ACTIONS
+        and isinstance(rule.get("enabled"), bool)
+        and isinstance(rule.get("connections", 1), int)
+        and 1 <= rule.get("connections", 1) <= 256
+    )
+
+
+def matchingSiteRule(url: str, rules: list[dict]) -> dict | None:
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        return None
+    for rule in rules:
+        if not validateSiteRule(rule) or not rule.get("enabled", True):
+            continue
+        for pattern in rule["hosts"]:
+            normalized = normalizeHost(pattern)
+            if host == normalized or fnmatch(host, normalized):
+                return rule
+    return None
+
+
+def publicSiteRules(rules: list[dict]) -> list[dict]:
+    """Return the safe subset sent to the paired browser extension."""
+    return [
+        {
+            "id": rule["id"],
+            "name": rule["name"],
+            "hosts": [normalizeHost(host) for host in rule["hosts"]],
+            "action": rule["action"],
+            "enabled": rule["enabled"],
+        }
+        for rule in rules
+        if validateSiteRule(rule)
+    ]

--- a/app/view/dialogs/site_rule_edit.py
+++ b/app/view/dialogs/site_rule_edit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from PySide6.QtWidgets import QHBoxLayout, QWidget
+from qfluentwidgets import BodyLabel, ComboBox, LineEdit, MessageBoxBase, SpinBox, SubtitleLabel, SwitchButton
+
+from app.site_rules import normalizeHost
+from app.view.components.token_line_edit import TokenLineEdit
+
+
+ACTION_ITEMS = [
+    ("standard", "标准下载"),
+    ("single_connection", "限制连接数"),
+    ("pixeldrain_api", "PixelDrain — 使用 API"),
+    ("uupdump_post", "UUP dump — 提交表单"),
+    ("prefer_latest_hls", "HLS — 优先选择最新媒体"),
+]
+
+
+class SiteRuleEditDialog(MessageBoxBase):
+    def __init__(self, parent=None, *, rule: dict | None = None):
+        super().__init__(parent)
+        self._rule = dict(rule) if rule else None
+        self.titleLabel = SubtitleLabel(self.tr("编辑规则") if rule else self.tr("添加规则"), self)
+        self.nameEdit = LineEdit(self)
+        self.hostsEdit = TokenLineEdit(self)
+        self.actionCombo = ComboBox(self)
+        self.connectionsSpin = SpinBox(self)
+        self.enabledRow = QWidget(self)
+        self.enabledLayout = QHBoxLayout(self.enabledRow)
+        self.enabledSwitch = SwitchButton(self.enabledRow)
+
+        self._initWidget()
+        self._initLayout()
+        self._populate()
+
+    def _initWidget(self) -> None:
+        self.widget.setMinimumWidth(540)
+        self.yesButton.setText(self.tr("保存"))
+        self.cancelButton.setText(self.tr("取消"))
+        self.nameEdit.setPlaceholderText(self.tr("规则名称"))
+        self.hostsEdit.setPlaceholderText(self.tr("输入域名并按 Enter"))
+        self.connectionsSpin.setRange(1, 256)
+        for value, text in ACTION_ITEMS:
+            self.actionCombo.addItem(self.tr(text), userData=value)
+
+    def _initLayout(self) -> None:
+        self.enabledLayout.setContentsMargins(0, 0, 0, 0)
+        self.enabledLayout.addWidget(BodyLabel(self.tr("启用规则"), self.enabledRow))
+        self.enabledLayout.addStretch(1)
+        self.enabledLayout.addWidget(self.enabledSwitch)
+
+        self.viewLayout.setSpacing(8)
+        self.viewLayout.addWidget(self.titleLabel)
+        self.viewLayout.addSpacing(8)
+        self.viewLayout.addWidget(BodyLabel(self.tr("名称"), self))
+        self.viewLayout.addWidget(self.nameEdit)
+        self.viewLayout.addWidget(BodyLabel(self.tr("域名"), self))
+        self.viewLayout.addWidget(self.hostsEdit)
+        self.viewLayout.addWidget(BodyLabel(self.tr("行为"), self))
+        self.viewLayout.addWidget(self.actionCombo)
+        self.viewLayout.addWidget(BodyLabel(self.tr("最大连接数"), self))
+        self.viewLayout.addWidget(self.connectionsSpin)
+        self.viewLayout.addWidget(self.enabledRow)
+
+    def _populate(self) -> None:
+        rule = self._rule
+        if rule is None:
+            self.connectionsSpin.setValue(1)
+            self.enabledSwitch.setChecked(True)
+            return
+        self.nameEdit.setText(str(rule.get("name", "")))
+        self.hostsEdit.setTokens(list(rule.get("hosts") or []))
+        self.connectionsSpin.setValue(int(rule.get("connections", 1)))
+        self.enabledSwitch.setChecked(bool(rule.get("enabled", True)))
+        index = self.actionCombo.findData(rule.get("action", "standard"))
+        self.actionCombo.setCurrentIndex(max(index, 0))
+
+    def validate(self) -> bool:
+        return bool(self.nameEdit.text().strip() and self._hosts())
+
+    def _hosts(self) -> list[str]:
+        result: list[str] = []
+        for token in self.hostsEdit.tokens():
+            host = normalizeHost(token)
+            if host and host not in result:
+                result.append(host)
+        return result
+
+    def rule(self) -> dict:
+        old = self._rule or {}
+        return {
+            "id": old.get("id") or f"custom_{uuid4().hex}",
+            "name": self.nameEdit.text().strip(),
+            "hosts": self._hosts(),
+            "action": self.actionCombo.currentData() or "standard",
+            "enabled": self.enabledSwitch.isChecked(),
+            "connections": self.connectionsSpin.value(),
+            "description": old.get("description", "Custom site rule."),
+        }

--- a/app/view/pages/site_rules_page.py
+++ b/app/view/pages/site_rules_page.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QCoreApplication, Qt
+from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
+from qfluentwidgets import (
+    BodyLabel, FluentIcon, IconWidget, InfoBar, InfoBarPosition,
+    PushButton, StrongBodyLabel, SubtitleLabel, SwitchButton,
+    ToolButton, ToolTipFilter,
+)
+
+from app.config.cfg import cfg
+from app.site_rules import defaultSiteRules
+from app.view.components.scroll_area import ScrollArea
+from app.view.components.setting_card_group import CollapsibleSettingCard
+
+
+ACTION_LABELS = {
+    "standard": "标准下载",
+    "single_connection": "限制连接数",
+    "pixeldrain_api": "API PixelDrain",
+    "uupdump_post": "UUP dump 表单",
+    "prefer_latest_hls": "最新 HLS",
+}
+
+
+def _tr(text: str) -> str:
+    return QCoreApplication.translate("SiteRulesPage", text)
+
+
+class SiteRuleRow(QWidget):
+    def __init__(self, rule: dict, onToggle, onEdit, onRemove, parent=None):
+        super().__init__(parent)
+        self.icon = IconWidget(FluentIcon.GLOBE, self)
+        self.name = StrongBodyLabel(str(rule.get("name", "")), self)
+        hosts = ", ".join(rule.get("hosts") or [])
+        action = _tr(ACTION_LABELS.get(rule.get("action"), str(rule.get("action", ""))))
+        self.summary = BodyLabel(f"{hosts}  •  {action}", self)
+        self.enabled = SwitchButton(self)
+        self.edit = ToolButton(FluentIcon.EDIT, self)
+        self.remove = ToolButton(FluentIcon.DELETE, self)
+
+        self.icon.setFixedSize(18, 18)
+        self.enabled.setChecked(bool(rule.get("enabled", True)))
+        self.edit.setToolTip(_tr("编辑"))
+        self.remove.setToolTip(_tr("删除"))
+        self.edit.installEventFilter(ToolTipFilter(self.edit))
+        self.remove.installEventFilter(ToolTipFilter(self.remove))
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(48, 10, 24, 10)
+        layout.setSpacing(12)
+        layout.addWidget(self.icon)
+        text = QVBoxLayout()
+        text.setSpacing(2)
+        text.addWidget(self.name)
+        text.addWidget(self.summary)
+        layout.addLayout(text, 1)
+        layout.addWidget(self.enabled)
+        layout.addWidget(self.edit)
+        layout.addWidget(self.remove)
+
+        ruleId = str(rule.get("id", ""))
+        self.enabled.checkedChanged.connect(lambda checked: onToggle(ruleId, checked))
+        self.edit.clicked.connect(lambda: onEdit(ruleId))
+        self.remove.clicked.connect(lambda: onRemove(ruleId))
+
+
+class SiteRulesPage(ScrollArea):
+    def __init__(self, browserService, parent=None):
+        super().__init__(parent)
+        self._browserService = browserService
+        self._rows: list[SiteRuleRow] = []
+        self.container = QWidget(self)
+        self.layout = QVBoxLayout(self.container)
+        self.title = SubtitleLabel(self.tr("站点规则"), self.container)
+        self.description = BodyLabel(
+            self.tr("按域名自动调整连接数、下载地址和媒体选择。"),
+            self.container,
+        )
+        self.rulesCard = CollapsibleSettingCard(
+            FluentIcon.DEVELOPER_TOOLS,
+            self.tr("智能规则"),
+            self.tr("更改将应用到 Ghost Downloader 和已连接的浏览器扩展。"),
+            self.container,
+        )
+        self.buttonRow = QWidget(self.rulesCard.view)
+        self.buttonLayout = QHBoxLayout(self.buttonRow)
+        self.resetButton = PushButton(FluentIcon.SYNC, self.tr("恢复默认值"), self.buttonRow)
+        self.addButton = PushButton(FluentIcon.ADD, self.tr("添加规则"), self.buttonRow)
+
+        self._initWidget()
+        self._initLayout()
+        self._bind()
+        self._reload()
+
+    def _initWidget(self) -> None:
+        self.setWidget(self.container)
+        self.setWidgetResizable(True)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.enableTransparentBackground()
+        self.setProperty("isStackedTransparent", False)
+
+    def _initLayout(self) -> None:
+        self.layout.setContentsMargins(36, 28, 36, 36)
+        self.layout.setSpacing(8)
+        self.layout.addWidget(self.title)
+        self.layout.addWidget(self.description)
+        self.layout.addSpacing(12)
+        self.layout.addWidget(self.rulesCard)
+        self.layout.addStretch(1)
+        self.rulesCard.viewLayout.setContentsMargins(0, 0, 0, 0)
+        self.rulesCard.viewLayout.setSpacing(0)
+        self.buttonLayout.setContentsMargins(48, 10, 24, 10)
+        self.buttonLayout.addStretch(1)
+        self.buttonLayout.addWidget(self.resetButton)
+        self.buttonLayout.addWidget(self.addButton)
+
+    def _bind(self) -> None:
+        self.addButton.clicked.connect(self._add)
+        self.resetButton.clicked.connect(self._reset)
+
+    def _rules(self) -> list[dict]:
+        return [dict(rule) for rule in cfg.siteRules.value]
+
+    def _save(self, rules: list[dict]) -> None:
+        cfg.set(cfg.siteRules, rules)
+        self._browserService.broadcastSiteRules()
+        self._reload()
+
+    def _reload(self) -> None:
+        for row in self._rows:
+            self.rulesCard.viewLayout.removeWidget(row)
+            row.deleteLater()
+        self._rows.clear()
+        self.rulesCard.viewLayout.removeWidget(self.buttonRow)
+        for rule in self._rules():
+            row = SiteRuleRow(rule, self._toggle, self._edit, self._remove, self.rulesCard.view)
+            self.rulesCard.viewLayout.addWidget(row)
+            self._rows.append(row)
+        self.rulesCard.viewLayout.addWidget(self.buttonRow)
+        self.rulesCard.card.setContent(self.tr("已配置 {count} 条规则").format(count=len(self._rows)))
+
+    def _toggle(self, ruleId: str, enabled: bool) -> None:
+        rules = self._rules()
+        for rule in rules:
+            if rule.get("id") == ruleId:
+                rule["enabled"] = enabled
+        cfg.set(cfg.siteRules, rules)
+        self._browserService.broadcastSiteRules()
+
+    def _add(self) -> None:
+        from app.view.dialogs.site_rule_edit import SiteRuleEditDialog
+        dialog = SiteRuleEditDialog(self.window())
+        if dialog.exec():
+            self._save([*self._rules(), dialog.rule()])
+
+    def _edit(self, ruleId: str) -> None:
+        rules = self._rules()
+        current = next((rule for rule in rules if rule.get("id") == ruleId), None)
+        if current is None:
+            return
+        from app.view.dialogs.site_rule_edit import SiteRuleEditDialog
+        dialog = SiteRuleEditDialog(self.window(), rule=current)
+        if dialog.exec():
+            self._save([dialog.rule() if rule.get("id") == ruleId else rule for rule in rules])
+
+    def _remove(self, ruleId: str) -> None:
+        self._save([rule for rule in self._rules() if rule.get("id") != ruleId])
+
+    def _reset(self) -> None:
+        self._save(defaultSiteRules())
+        InfoBar.success(
+            title=self.tr("规则已恢复"),
+            content=self.tr("已恢复 PixelDrain、UUP dump 和 HDSex 默认规则。"),
+            position=InfoBarPosition.TOP_RIGHT,
+            parent=self.window(),
+        )

--- a/app/view/windows/main_window.py
+++ b/app/view/windows/main_window.py
@@ -19,6 +19,7 @@ from app.services.task_draft import TaskDraft
 from app.signal_bus import signalBus
 from app.services.update_service import UpdateState
 from app.view.pages.setting_page import SettingPage
+from app.view.pages.site_rules_page import SiteRulesPage
 from app.view.pages.task_page import TaskPage
 
 if TYPE_CHECKING:
@@ -128,6 +129,8 @@ class MainWindow(MSFluentWindow):
     def _initLayout(self) -> None:
         self._addPage(TaskPage, FluentIcon.DOWNLOAD, self.tr("下载任务"),
                       NavigationItemPosition.TOP)
+        self._addPage(SiteRulesPage, FluentIcon.DEVELOPER_TOOLS, self.tr("站点规则"),
+                      NavigationItemPosition.TOP)
         self.navigationInterface.addItem(
             routeKey="addTaskButton",
             text=self.tr("新建任务"),
@@ -192,6 +195,8 @@ class MainWindow(MSFluentWindow):
                 self._coroutineRunner, self._categoryService, self._taskService,
                 self._updateService, parent=self,
             )
+        if pageClass is SiteRulesPage:
+            return SiteRulesPage(self._browserService, parent=self)
         return self._featureService.createPage(pageClass, parent=self)
 
     def _onSearchTextChanged(self, text: str) -> None:

--- a/browser_extension/app/package.json
+++ b/browser_extension/app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node ./scripts/build.mjs",
+    "test": "node ./scripts/test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/browser_extension/app/scripts/test.mjs
+++ b/browser_extension/app/scripts/test.mjs
@@ -1,0 +1,22 @@
+import {execFileSync} from "node:child_process";
+import {mkdtempSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {build} from "esbuild";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outputDir = mkdtempSync(path.join(tmpdir(), "ghost-extension-tests-"));
+try {
+  const output = path.join(outputDir, "site-rules.test.mjs");
+  await build({
+    entryPoints: [path.join(root, "tests/site-rules.test.ts")],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile: output,
+  });
+  execFileSync(process.execPath, ["--test", output], {stdio: "inherit"});
+} finally {
+  rmSync(outputDir, {recursive: true, force: true});
+}

--- a/browser_extension/app/src/background.ts
+++ b/browser_extension/app/src/background.ts
@@ -3,6 +3,7 @@ import type {
     TaskSummary,
     PopupState,
     PopupView,
+    SiteRule,
 } from "./shared/types";
 import type {PopupCommand} from "./shared/popup-protocol";
 import {createDesktopBridge} from "./background/desktop-bridge";
@@ -63,6 +64,18 @@ async function sendTaskOrEnqueue<T extends CommandResult>(payload: Record<string
 }
 
 const openWhenDoneIds = new Set<string>();
+let siteRules: SiteRule[] = [];
+
+async function broadcastSiteRules(rules: SiteRule[]): Promise<void> {
+  siteRules = rules;
+  const tabs = await queryTabs({});
+  for (const tab of tabs) {
+    if (!tab.id || !tab.url || !/^https?:/i.test(tab.url)) { continue; }
+    chrome.tabs.sendMessage(tab.id, {type: "site_rules_updated", rules}, () => {
+      void chrome.runtime.lastError;
+    });
+  }
+}
 
 function onTaskSnapshotChanged(tasks: TaskSummary[]): void {
   updateIconForTasks(tasks);
@@ -81,6 +94,7 @@ function onTaskSnapshotChanged(tasks: TaskSummary[]): void {
 const desktopBridge = createDesktopBridge({
   onTaskSnapshotChanged,
   onConnected: () => void flushQueue(),
+  onSiteRulesChanged: (rules) => void broadcastSiteRules(rules),
 });
 const resourceBridge = createResourceBridge({
   sendDesktopRequest: (payload) => sendTaskOrEnqueue(payload),
@@ -124,6 +138,9 @@ async function injectMediaButton(tabId: number) {
       files: ["page-media-overlay.js"],
       injectImmediately: false,
       target: { tabId, allFrames: true },
+    });
+    chrome.tabs.sendMessage(tabId, {type: "site_rules_updated", rules: siteRules}, () => {
+      void chrome.runtime.lastError;
     });
   } catch {
     // chrome:// and similar reject injection.

--- a/browser_extension/app/src/background/desktop-bridge.ts
+++ b/browser_extension/app/src/background/desktop-bridge.ts
@@ -1,5 +1,5 @@
 import {DEFAULT_SERVER_URL} from "../shared/constants";
-import type {DesktopConnectionState, CommandResult, TaskSummary,} from "../shared/types";
+import type {DesktopConnectionState, CommandResult, SiteRule, TaskSummary,} from "../shared/types";
 import {PAIR_TOKEN_KEY, PROTOCOL_VERSION, RECONNECT_ALARM, SERVER_URL_KEY,} from "./constants";
 import {loadLocalState, saveLocalState} from "./chrome-helpers";
 
@@ -32,6 +32,7 @@ export type DesktopBridgeSnapshot = {
 export interface DesktopBridgeOptions {
   onTaskSnapshotChanged?: (tasks: TaskSummary[]) => void;
   onConnected?: () => void;
+  onSiteRulesChanged?: (rules: SiteRule[]) => void;
 }
 
 export function createDesktopBridge(options: DesktopBridgeOptions = {}) {
@@ -106,6 +107,14 @@ export function createDesktopBridge(options: DesktopBridgeOptions = {}) {
       setConnectionState("connected", chrome.i18n.getMessage("connected"));
       desktopSocket?.send(JSON.stringify({ type: "subscribe_tasks" }));
       options.onConnected?.();
+      if (Array.isArray(message.siteRules)) {
+        options.onSiteRulesChanged?.(message.siteRules as SiteRule[]);
+      }
+      return;
+    }
+
+    if (message.type === "site_rules" && Array.isArray(message.rules)) {
+      options.onSiteRulesChanged?.(message.rules as SiteRule[]);
       return;
     }
 

--- a/browser_extension/app/src/page-media/download-button/download-button.ts
+++ b/browser_extension/app/src/page-media/download-button/download-button.ts
@@ -6,6 +6,7 @@
  */
 import {findActiveMedia} from "./active-media";
 import type {VideoSessionState} from "../types";
+import type {SiteRule} from "../../shared/types";
 
 declare global {
   interface Window {
@@ -33,6 +34,7 @@ const FADE_DURATION_MS = 300;
   let lastMouseX = -1;
   let lastMouseY = -1;
   let dismissed = false;
+  let siteRules: SiteRule[] = [];
   let dragOffsetX = 0;
   let dragOffsetY = 0;
   const DRAG_THRESHOLD = 5;
@@ -298,6 +300,7 @@ const FADE_DURATION_MS = 300;
     try {
       const resolution = await pageMedia.selectMediaForElement(media, {
         poster: media.poster || "",
+        siteRules,
       }, onState);
       if (!resolution || resolution.kind === "refused") {
         setStatus(resolution?.message || chrome.i18n.getMessage("errorCannotLocateMedia"), true);
@@ -393,6 +396,11 @@ const FADE_DURATION_MS = 300;
   document.addEventListener("loadedmetadata", scheduleUpdate, true);
 
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message?.type === "site_rules_updated" && Array.isArray(message.rules)) {
+      siteRules = message.rules as SiteRule[];
+      sendResponse({ok: true});
+      return false;
+    }
     if (message?.type !== "media_button_set_enabled") { return; }
     Boolean(message.enabled) ? enableOverlay() : disableOverlay();
     sendResponse({ ok: true });

--- a/browser_extension/app/src/page-media/resolution/strategies/generic.ts
+++ b/browser_extension/app/src/page-media/resolution/strategies/generic.ts
@@ -1,5 +1,5 @@
 import {classifyTrackRole, isDashSegmentUrl, isStreamUrl, stripRangeParams} from "../url-classify";
-import {newestMatching, postBindAttributedUrls, selectMergePair} from "../strategy";
+import {newestBy, newestMatching, postBindAttributedUrls, selectMergePair} from "../strategy";
 import type {ResolveContext} from "../strategy";
 import type {Resolution} from "../../types";
 
@@ -7,7 +7,22 @@ import type {Resolution} from "../../types";
 export function selectGeneric(ctx: ResolveContext): Resolution {
   const post = postBindAttributedUrls(ctx.clicked);
 
-  const master = post.find((r) => r.isMaster);
+  const host = ctx.pageUrl.hostname.toLowerCase();
+  const preferLatestHls = (ctx.hints.siteRules ?? []).some((rule) =>
+    rule.enabled
+    && rule.action === "prefer_latest_hls"
+    && rule.hosts.some((pattern) => {
+      const normalized = pattern.toLowerCase().replace(/^\*\./, "");
+      return host === normalized || host.endsWith(`.${normalized}`);
+    }),
+  );
+
+  // Players reused after a pre-roll retain both HLS manifests. Rule-enabled sites
+  // deliberately take the most recently captured master, which belongs to the main video.
+  const masters = post.filter((r) => r.isMaster);
+  const master = preferLatestHls
+    ? newestBy(masters, (entry) => entry.capturedAt)
+    : masters[0];
   if (master) {
     return { kind: "selection", selection: { kind: "stream", url: master.url } };
   }

--- a/browser_extension/app/src/page-media/resolution/strategy.ts
+++ b/browser_extension/app/src/page-media/resolution/strategy.ts
@@ -4,6 +4,7 @@ import {selectMeta} from "./strategies/instagram";
 import {selectYouTube} from "./strategies/youtube";
 import {isStreamUrl} from "./url-classify";
 import type {Resolution, VideoSessionFormKind} from "../types";
+import type {SiteRule} from "../../shared/types";
 
 // One attributed URL as the strategies see it — also the element type of
 // SessionSnapshot.attributedUrls and of a FindUrlsByIdHint return.
@@ -23,6 +24,7 @@ export type SessionSnapshot = {
 
 export type ResolveHints = {
   readonly poster: string;
+  readonly siteRules?: ReadonlyArray<SiteRule>;
 };
 
 export type ResolveContext = {

--- a/browser_extension/app/src/shared/types.ts
+++ b/browser_extension/app/src/shared/types.ts
@@ -12,6 +12,14 @@ export type MediaAction =
   | "fullscreen";
 export type ThemePreference = "system" | "light" | "dark";
 
+export type SiteRule = {
+  id: string;
+  name: string;
+  hosts: string[];
+  action: string;
+  enabled: boolean;
+};
+
 export type DesktopConnectionState =
   | "missing_token"
   | "connecting"

--- a/browser_extension/app/tests/site-rules.test.ts
+++ b/browser_extension/app/tests/site-rules.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {selectGeneric} from "../src/page-media/resolution/strategies/generic";
+import type {ResolveContext} from "../src/page-media/resolution/strategy";
+
+globalThis.chrome = {i18n: {getMessage: (key: string) => key}} as typeof chrome;
+
+function context(enabled: boolean): ResolveContext {
+  return {
+    clicked: {
+      formKind: "unknown",
+      lastBoundAt: 10,
+      attributedUrls: [
+        {url: "https://cdn.test/advert/master.m3u8", contentType: "application/vnd.apple.mpegurl", capturedAt: 20, isMaster: true},
+        {url: "https://cdn.test/main/master.m3u8", contentType: "application/vnd.apple.mpegurl", capturedAt: 30, isMaster: true},
+      ],
+    },
+    pageUrl: new URL("https://hdsex.org/shemale/video/776062386"),
+    hints: {
+      poster: "",
+      siteRules: [{id: "hdsex", name: "HDSex", hosts: ["hdsex.org"], action: "prefer_latest_hls", enabled}],
+    },
+  };
+}
+
+test("HDSex rule skips the older pre-roll HLS", () => {
+  const result = selectGeneric(context(true));
+  assert.equal(result.kind, "selection");
+  if (result.kind === "selection" && result.selection.kind === "stream") {
+    assert.equal(result.selection.url, "https://cdn.test/main/master.m3u8");
+  }
+});
+
+test("disabling HDSex rule preserves generic first-master behavior", () => {
+  const result = selectGeneric(context(false));
+  assert.equal(result.kind, "selection");
+  if (result.kind === "selection" && result.selection.kind === "stream") {
+    assert.equal(result.selection.url, "https://cdn.test/advert/master.m3u8");
+  }
+});

--- a/browser_extension/app/tsconfig.json
+++ b/browser_extension/app/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "noEmit": true,
     "jsx": "react-jsx",

--- a/features/http_pack/pack.py
+++ b/features/http_pack/pack.py
@@ -16,6 +16,7 @@ from app.models.task import (
     Task, TaskOptions, ResourceTaskOptions, SpecialFileSize,
 )
 from app.platform.filesystem import toSafeFilename
+from app.site_rules import matchingSiteRule
 from .cards import HttpTaskCard
 from .task import HttpTask, HttpTaskStep
 
@@ -29,6 +30,36 @@ DOWNLOADABLE_EXTENSIONS = frozenset({
     ".pdf", ".epub",
     ".apk", ".ipa",
 })
+
+PIXELDRAIN_HOSTS = frozenset({"pixeldrain.com", "www.pixeldrain.com"})
+UUPDUMP_HOSTS = frozenset({"uupdump.net", "www.uupdump.net"})
+
+
+def parsePixelDrainUrl(url: str) -> tuple[str, str] | None:
+    """Return the API file URL and viewer URL for a PixelDrain viewer link."""
+    parsed = urlparse(url)
+    if parsed.hostname is None or parsed.hostname.lower() not in PIXELDRAIN_HOSTS:
+        return None
+
+    parts = [unquote(part) for part in parsed.path.split("/") if part]
+    if len(parts) != 2 or parts[0].lower() != "u" or not parts[1]:
+        return None
+
+    fileId = parts[1]
+    viewerUrl = f"https://pixeldrain.com/u/{fileId}"
+    return f"https://pixeldrain.com/api/file/{fileId}?download", viewerUrl
+
+
+def parseUupDumpUrl(url: str) -> tuple[str, str] | None:
+    parsed = urlparse(url)
+    if parsed.hostname is None or parsed.hostname.lower() not in UUPDUMP_HOSTS:
+        return None
+    if parsed.path.lower() not in {"/download.php", "/get.php"}:
+        return None
+
+    query = f"?{parsed.query}" if parsed.query else ""
+    pageUrl = f"https://uupdump.net/download.php{query}"
+    return f"https://uupdump.net/get.php{query}", pageUrl
 
 
 class HttpParser(TaskParser):
@@ -52,6 +83,28 @@ class HttpParser(TaskParser):
         subworkerCount = options.subworkerCount
         outputFolder = options.outputFolder
 
+        siteRule = matchingSiteRule(url, cfg.siteRules.value)
+        action = siteRule.get("action") if siteRule else "standard"
+
+        pixelDrain = parsePixelDrainUrl(url) if action == "pixeldrain_api" else None
+        if pixelDrain is not None:
+            url, viewerUrl = pixelDrain
+            if not any(key.lower() == "referer" for key in headers):
+                headers["referer"] = viewerUrl
+            # Free PixelDrain downloads reject excessive concurrent connections.
+            subworkerCount = int(siteRule.get("connections", 1))
+
+        postForm: dict[str, str] = {}
+        uupDump = parseUupDumpUrl(url) if action == "uupdump_post" else None
+        if uupDump is not None:
+            url, pageUrl = uupDump
+            if not any(key.lower() == "referer" for key in headers):
+                headers["referer"] = pageUrl
+            postForm = {"autodl": "2", "updates": "1"}
+            subworkerCount = int(siteRule.get("connections", 1))
+
+        if siteRule and action == "single_connection":
+            subworkerCount = int(siteRule.get("connections", 1))
         name = ""
         fileSize = SpecialFileSize.UNKNOWN
         canUseRangeRequests = False
@@ -97,7 +150,10 @@ class HttpParser(TaskParser):
                 probeHeaders["accept-encoding"] = "identity"
                 if rangeValue:
                     probeHeaders["range"] = rangeValue
-                response = await client.get(url, headers=probeHeaders)
+                if postForm:
+                    response = await client.post(url, headers=probeHeaders, form=postForm)
+                else:
+                    response = await client.get(url, headers=probeHeaders)
                 try:
                     status = response.status.as_int()
                     if status not in {200, 206, 416}:
@@ -204,6 +260,7 @@ class HttpParser(TaskParser):
             subworkerCount=subworkerCount,
             canUseRangeRequests=canUseRangeRequests,
             lastModified=lastModified,
+            postForm=postForm,
         ))
         return task
 
@@ -233,4 +290,3 @@ class HttpPack(FeaturePack):
             UrlEditCard(parent, initial=task.url),
             *self.optionCards(task, parent),
         ]
-

--- a/features/http_pack/task.py
+++ b/features/http_pack/task.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from app.client import buildClient, toEmulation
 from app.config.cfg import cfg
+from app.site_rules import matchingSiteRule
 from app.models.task import Task, TaskError, TaskStep, TaskStatus, SpecialFileSize
 from app.platform.sysio import ftruncate, pwrite
 
@@ -28,6 +29,10 @@ class PermanentDownloadError(Exception):
 
 
 class RangeNotSupportedError(Exception):
+    pass
+
+
+class UnexpectedContentError(Exception):
     pass
 
 
@@ -69,6 +74,7 @@ class HttpTaskStep(TaskStep):
     lastModified: str = ""
     isAccelerated: bool = False
     outputFile: str = ""
+    postForm: dict[str, str] = field(default_factory=dict)
     subworkers: list[HttpSubworker] = field(default_factory=list, repr=False)
 
     @property
@@ -261,13 +267,18 @@ class HttpTaskStep(TaskStep):
         finally:
             client.close()
 
+    async def _request(self, client, url: str, headers: dict[str, str]):
+        if self.postForm:
+            return await client.post(url, headers=headers, form=self.postForm)
+        return await client.get(url, headers=headers)
+
     async def _runSubworkerWith(self, subworker: HttpSubworker, fd: int, client) -> None:
         if subworker.end == SpecialFileSize.UNKNOWN:
             while True:
                 try:
                     httpPos = self.httpByteOffset + subworker.position
                     headers = {**self._effectiveHeaders, "range": f"bytes={httpPos}-", "accept-encoding": "identity"}
-                    response = await client.get(self._effectiveUrl, headers=headers)
+                    response = await self._request(client, self._effectiveUrl, headers)
                     try:
                         status = response.status.as_int()
                         if status in PERMANENT_STATUS or response.headers.contains_key("cf-mitigated"):
@@ -301,13 +312,16 @@ class HttpTaskStep(TaskStep):
                 try:
                     ftruncate(fd, 0)
                     subworker.receivedBytes = 0
-                    response = await client.get(self._effectiveUrl, headers=dict(self._effectiveHeaders))
+                    response = await self._request(client, self._effectiveUrl, dict(self._effectiveHeaders))
                     try:
                         status = response.status.as_int()
                         if status in PERMANENT_STATUS or response.headers.contains_key("cf-mitigated"):
                             raise PermanentDownloadError(status)
                         if status != 200:
                             raise Exception(f"服务器返回了异常状态码：{status}")
+                        contentType = response.headers.get("content-type", b"").decode(errors="replace").lower()
+                        if self.task.name.lower().endswith(".zip") and "text/html" in contentType:
+                            raise UnexpectedContentError("服务器返回了 HTML 页面，而不是 ZIP 文件")
                         async for chunk in response.stream():
                             if not chunk:
                                 continue
@@ -322,6 +336,8 @@ class HttpTaskStep(TaskStep):
                 except CancelledError:
                     raise
                 except PermanentDownloadError:
+                    raise
+                except UnexpectedContentError:
                     raise
                 except Exception as e:
                     if isinstance(e, OSError) and e.errno in FATAL_IO_ERRNO:
@@ -339,7 +355,7 @@ class HttpTaskStep(TaskStep):
                         "range": f"bytes={httpPos}-{httpEnd}",
                         "accept-encoding": "identity",
                     }
-                    response = await client.get(self._effectiveUrl, headers=headers)
+                    response = await self._request(client, self._effectiveUrl, headers)
                     try:
                         status = response.status.as_int()
                         if status in PERMANENT_STATUS or response.headers.contains_key("cf-mitigated"):
@@ -393,10 +409,18 @@ class HttpTaskStep(TaskStep):
 
         self._emulation = toEmulation(self.clientProfile or cfg.clientProfile.value, "")
 
+        siteRule = matchingSiteRule(self.url, cfg.siteRules.value)
+        isPixelDrain = bool(siteRule and siteRule.get("action") == "pixeldrain_api")
+        if isPixelDrain:
+            # PixelDrain free accounts allow only a small number of simultaneous
+            # connections. Old/restored tasks may still contain the former default,
+            # and auto speed-up would otherwise split this stream again later.
+            self.subworkerCount = 1
+            self.isAccelerated = True
         probeHeaders = {**self._effectiveHeaders, "range": "bytes=0-0", "accept-encoding": "identity"}
         client = buildClient(emulation=self._emulation, userAgent=self.userAgent or None, timeout=30)
         try:
-            response = await client.get(self.url, headers=probeHeaders)
+            response = await self._request(client, self.url, probeHeaders)
             self._effectiveUrl = str(response.url)
             response.close()
         finally:
@@ -406,7 +430,16 @@ class HttpTaskStep(TaskStep):
         if self.canUseRangeRequests:
             loaded = self._loadRecord()
             if loaded:
-                self.subworkers = loaded
+                if isPixelDrain and self.fileSize > 0:
+                    firstMissing = min(sw.position for sw in loaded)
+                    self.subworkers = [HttpSubworker(
+                        index=0,
+                        start=0,
+                        end=self.fileSize - 1,
+                        receivedBytes=min(firstMissing, self.fileSize),
+                    )]
+                else:
+                    self.subworkers = loaded
                 restored = True
 
         if not restored:
@@ -461,6 +494,8 @@ class HttpTaskStep(TaskStep):
                     cause = eg.exceptions[0]
                     if isinstance(cause, PermanentDownloadError):
                         raise TaskError("服务器返回了错误（{status}）", status=cause.status) from eg
+                    if isinstance(cause, UnexpectedContentError):
+                        raise TaskError(str(cause)) from eg
                     if isinstance(cause, OSError) and cause.errno in FATAL_IO_ERRNO:
                         raise TaskError("磁盘空间不足") from eg
                     raise cause from eg

--- a/tests/test_http_site_fixes.py
+++ b/tests/test_http_site_fixes.py
@@ -1,0 +1,23 @@
+from features.http_pack.pack import parsePixelDrainUrl, parseUupDumpUrl
+
+
+def test_pixeldrain_viewer_url_becomes_api_download():
+    assert parsePixelDrainUrl("https://pixeldrain.com/u/abc123") == (
+        "https://pixeldrain.com/api/file/abc123?download",
+        "https://pixeldrain.com/u/abc123",
+    )
+
+
+def test_uupdump_download_url_becomes_post_endpoint():
+    url = (
+        "https://uupdump.net/download.php?"
+        "id=c1c737c2-f2d9-4824-bb5b-1af515179099&"
+        "pack=pt-br&edition=professional"
+    )
+
+    assert parseUupDumpUrl(url) == (
+        "https://uupdump.net/get.php?"
+        "id=c1c737c2-f2d9-4824-bb5b-1af515179099&"
+        "pack=pt-br&edition=professional",
+        url,
+    )

--- a/tests/test_site_rules.py
+++ b/tests/test_site_rules.py
@@ -1,0 +1,24 @@
+from app.site_rules import defaultSiteRules, matchingSiteRule, publicSiteRules, validateSiteRule
+
+
+def test_default_rules_cover_known_sites():
+    rules = defaultSiteRules()
+    assert matchingSiteRule("https://pixeldrain.com/u/example", rules)["action"] == "pixeldrain_api"
+    assert matchingSiteRule("https://www.uupdump.net/download.php?id=x", rules)["action"] == "uupdump_post"
+    assert matchingSiteRule("https://hdsex.org/shemale/video/776062386?x=1", rules)["action"] == "prefer_latest_hls"
+
+
+def test_disabled_rule_does_not_match():
+    rules = defaultSiteRules()
+    rules[0]["enabled"] = False
+    assert matchingSiteRule("https://pixeldrain.com/u/example", rules) is None
+
+
+def test_public_rules_strip_desktop_only_fields():
+    rules = publicSiteRules(defaultSiteRules())
+    assert all(set(rule) == {"id", "name", "hosts", "action", "enabled"} for rule in rules)
+    assert all("description" not in rule and "connections" not in rule for rule in rules)
+
+
+def test_full_default_rules_are_valid():
+    assert all(validateSiteRule(rule) for rule in defaultSiteRules())


### PR DESCRIPTION
## Summary

Adds configurable per-site compatibility rules shared by the desktop app and browser extension.

The initial rules address three confirmed download failures:

- **PixelDrain:** converts viewer URLs to the file API, sends the correct Referer, limits the transfer to one connection, and safely resumes older multi-range tasks as a single stream. This avoids HTTP 403 responses, free-tier throttling loops, and corrupted downloads.
- **UUP dump:** converts `download.php` links to the required `get.php` POST request, preserves query parameters, sends the expected form data, and rejects HTML error pages returned in place of ZIP files.
- **HLS pre-roll players:** optionally selects the newest captured HLS master for configured domains, preventing an earlier advertisement stream from being downloaded instead of the main video.

A native **Site Rules** page lets users enable, disable, add, edit, remove, and restore rules without rebuilding the application. Rule updates are sent live to the connected browser extension.

## Implementation notes

- Rules are validated and persisted through the existing configuration system.
- Only a safe rule subset is exposed to the extension.
- Generic behavior remains unchanged when no enabled rule matches.
- No release artifacts, signed extensions, downstream workflows, or platform removals are included.

## Tests

- Python syntax checks passed for all changed modules.
- `tests/test_site_rules.py`: 4 passed.
- Browser extension rule tests: 2 passed.
- TypeScript typecheck passed.
- Chromium and Firefox production builds passed.
- Added URL conversion tests for PixelDrain and UUP dump.
