### PR TITLE
Fix UUPDump downloads and Pixeldrain single-connection handling

### DIFF
--- a/features/http_pack/pack.py
+++ b/features/http_pack/pack.py
@@ -18,6 +18,11 @@ from app.models.task import (
 from app.platform.filesystem import toSafeFilename
 from .cards import HttpTaskCard
 from .task import HttpTask, HttpTaskStep
+from .site_rules import (
+    SingleConnectionHttpTaskStep,
+    UupdumpPostTaskStep,
+    apply_http_site_rule,
+)
 
 
 DOWNLOADABLE_EXTENSIONS = frozenset({
@@ -45,24 +50,31 @@ class HttpParser(TaskParser):
         return any(path.endswith(ext) for ext in DOWNLOADABLE_EXTENSIONS)
 
     async def parse(self, options: TaskOptions) -> Task:
-        url = options.url
-        headers = dict(options.headers)
+        siteRule = apply_http_site_rule(options.url, dict(options.headers), options.subworkerCount)
+        url = siteRule.url
+        headers = siteRule.headers
         clientProfile = options.clientProfile
         userAgent = options.userAgent
-        subworkerCount = options.subworkerCount
+        subworkerCount = siteRule.subworkerCount
         outputFolder = options.outputFolder
 
         name = ""
         fileSize = SpecialFileSize.UNKNOWN
         canUseRangeRequests = False
         lastModified = ""
+        preferResponseFilename = False
 
         if isinstance(options, ResourceTaskOptions) and options.name:
             name = toSafeFilename(options.name, fallback=f"file_{time_ns()}")
             fileSize = options.size if options.size > 0 else SpecialFileSize.UNKNOWN
             canUseRangeRequests = options.canUseRangeRequests
 
-        if fileSize == SpecialFileSize.UNKNOWN:
+        if siteRule.action == "uupdump_post":
+            canUseRangeRequests = False
+            if not name:
+                name = f"uupdump_{time_ns()}.download"
+                preferResponseFilename = True
+        elif fileSize == SpecialFileSize.UNKNOWN:
             emulation = toEmulation(
                 options.clientProfile or cfg.clientProfile.value,
                 options.sourceUserAgent,
@@ -194,7 +206,13 @@ class HttpParser(TaskParser):
             fileSize=fileSize,
             outputFolder=outputFolder,
         )
-        task.addStep(HttpTaskStep(
+        stepClass = HttpTaskStep
+        if siteRule.action == "single_connection":
+            stepClass = SingleConnectionHttpTaskStep
+        elif siteRule.action == "uupdump_post":
+            stepClass = UupdumpPostTaskStep
+
+        step = stepClass(
             stepIndex=1,
             url=url,
             fileSize=fileSize,
@@ -204,7 +222,12 @@ class HttpParser(TaskParser):
             subworkerCount=subworkerCount,
             canUseRangeRequests=canUseRangeRequests,
             lastModified=lastModified,
-        ))
+        )
+        if isinstance(step, UupdumpPostTaskStep):
+            step.requestBody = siteRule.requestBody
+            step.requestContentType = siteRule.requestContentType
+            step.preferResponseFilename = preferResponseFilename
+        task.addStep(step)
         return task
 
 
@@ -233,4 +256,3 @@ class HttpPack(FeaturePack):
             UrlEditCard(parent, initial=task.url),
             *self.optionCards(task, parent),
         ]
-

--- a/features/http_pack/site_rules.py
+++ b/features/http_pack/site_rules.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from email.message import Message
+from email.utils import collapse_rfc2231_value, parsedate_to_datetime
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from loguru import logger
+
+from app.client import buildClient, toEmulation
+from app.config.cfg import cfg
+from app.models.task import TaskError, TaskStatus
+from app.platform.filesystem import toSafeFilename
+from .task import HttpTaskStep, PERMANENT_STATUS
+
+UUPDUMP_BODY = "autodl=2&updates=1"
+UUPDUMP_CONTENT_TYPE = "application/x-www-form-urlencoded"
+
+@dataclass(frozen=True)
+class HttpSiteRule:
+    url: str
+    headers: dict[str, str]
+    subworkerCount: int
+    action: str = "standard"
+    requestBody: str = ""
+    requestContentType: str = ""
+
+def _is_host(host: str, domain: str) -> bool:
+    host = host.lower().rstrip(".")
+    domain = domain.lower().rstrip(".")
+    return host == domain or host.endswith("." + domain)
+
+def _origin(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+def _uupdump_urls(url: str) -> tuple[str, str] | None:
+    parsed = urlparse(url)
+    if not _is_host(parsed.hostname or "", "uupdump.net"):
+        return None
+    path = parsed.path.lower().lstrip("/")
+    if path not in {"download.php", "get.php"}:
+        return None
+    query = f"?{parsed.query}" if parsed.query else ""
+    return f"https://uupdump.net/get.php{query}", f"https://uupdump.net/download.php{query}"
+
+def _filename_from_content_disposition(value: str | bytes | None) -> str:
+    if not value:
+        return ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    msg = Message()
+    msg["Content-Disposition"] = value
+    params = msg.get_params(header="Content-Disposition") or []
+    paramDict = {str(k).lower(): v for k, v in params}
+    filename = paramDict.get("filename") or paramDict.get("filename*") or ""
+    if not filename:
+        return ""
+    filename = unquote(collapse_rfc2231_value(filename)).strip("\"' ")
+    return toSafeFilename(filename, fallback="") if filename else ""
+
+def apply_http_site_rule(url: str, headers: dict[str, str], subworkerCount: int) -> HttpSiteRule:
+    uupdump = _uupdump_urls(url)
+    if uupdump is not None:
+        downloadUrl, referer = uupdump
+        effectiveHeaders = dict(headers)
+        effectiveHeaders["Referer"] = referer
+        effectiveHeaders["Origin"] = _origin(referer)
+        effectiveHeaders["Content-Type"] = UUPDUMP_CONTENT_TYPE
+        return HttpSiteRule(downloadUrl, effectiveHeaders, 1, "uupdump_post", UUPDUMP_BODY, UUPDUMP_CONTENT_TYPE)
+    parsed = urlparse(url)
+    if _is_host(parsed.hostname or "", "pixeldrain.com"):
+        return HttpSiteRule(url, dict(headers), 1, "single_connection")
+    return HttpSiteRule(url, dict(headers), subworkerCount)
+
+class SingleConnectionHttpTaskStep(HttpTaskStep):
+    def _reassignSubworker(self) -> None:
+        return
+    def _autoSpeedUp(self) -> None:
+        return
+
+class UupdumpPostTaskStep(SingleConnectionHttpTaskStep):
+    requestBody: str = UUPDUMP_BODY
+    requestContentType: str = UUPDUMP_CONTENT_TYPE
+    preferResponseFilename: bool = False
+
+    @property
+    def canPause(self) -> bool:
+        return False
+
+    async def run(self, reportSpeed, waitForSpeedLimit) -> None:
+        self._reportSpeed = reportSpeed
+        self._waitForSpeedLimit = waitForSpeedLimit
+        Path(self.outputPath).parent.mkdir(parents=True, exist_ok=True)
+        headers = dict(self.headers)
+        headers["Content-Type"] = self.requestContentType or UUPDUMP_CONTENT_TYPE
+        headers["Accept-Encoding"] = "identity"
+        if self.userAgent and not any(k.lower() == "user-agent" for k in headers):
+            headers["User-Agent"] = self.userAgent
+        emulation = toEmulation(self.clientProfile or cfg.clientProfile.value, "")
+        while True:
+            client = buildClient(emulation=emulation, userAgent=self.userAgent or None, readTimeout=30)
+            try:
+                self.receivedBytes = 0
+                self.progress = 0
+                response = await client.post(self.url, headers=headers, body=(self.requestBody or UUPDUMP_BODY).encode("utf-8"))
+                try:
+                    status = response.status.as_int()
+                    if status in PERMANENT_STATUS or response.headers.contains_key("cf-mitigated"):
+                        raise TaskError("服务器返回了错误（{status}）", status=status)
+                    if status not in {200, 206}:
+                        response.raise_for_status()
+                    if self.preferResponseFilename:
+                        responseName = _filename_from_content_disposition(response.headers.get("content-disposition"))
+                        if responseName:
+                            self.task.name = responseName
+                    Path(self.outputPath).parent.mkdir(parents=True, exist_ok=True)
+                    with open(self.outputPath, "wb") as output:
+                        async for chunk in response.stream():
+                            if not chunk:
+                                continue
+                            output.write(chunk)
+                            self.receivedBytes += len(chunk)
+                            if self.fileSize > 0:
+                                self.progress = min(100.0, self.receivedBytes / self.fileSize * 100)
+                            self._reportSpeed(len(chunk))
+                            await self._waitForSpeedLimit()
+                    if self.fileSize <= 0:
+                        self.fileSize = self.receivedBytes
+                        self.task.fileSize = self.receivedBytes
+                    self.progress = 100
+                    self.setStatus(TaskStatus.COMPLETED)
+                    if cfg.shouldPreserveLastModified.value and self.lastModified:
+                        try:
+                            mtime = parsedate_to_datetime(self.lastModified).timestamp()
+                            import os
+                            os.utime(self.outputPath, (mtime, mtime))
+                        except Exception as error:
+                            logger.opt(exception=error).warning("设置文件修改时间失败 {}", self.outputPath)
+                    return
+                finally:
+                    response.close()
+            except asyncio.CancelledError:
+                self.setStatus(TaskStatus.PAUSED)
+                raise
+            except TaskError:
+                raise
+            except Exception as error:
+                logger.opt(exception=error).error("UUP dump 下载失败，将在 5 秒后重试 {}", self.outputPath)
+                await asyncio.sleep(5)
+            finally:
+                client.close()

--- a/tests/test_http_site_rules.py
+++ b/tests/test_http_site_rules.py
@@ -1,0 +1,52 @@
+from features.http_pack.site_rules import (
+    UUPDUMP_BODY,
+    UUPDUMP_CONTENT_TYPE,
+    _filename_from_content_disposition,
+    _uupdump_urls,
+    apply_http_site_rule,
+)
+
+
+def test_uupdump_download_url_becomes_get_post_endpoint():
+    url = "https://uupdump.net/download.php?id=abc&pack=pt-br&edition=professional"
+    download, referer = _uupdump_urls(url)
+    assert download == "https://uupdump.net/get.php?id=abc&pack=pt-br&edition=professional"
+    assert referer == url
+
+
+def test_uupdump_rule_preserves_query_and_sets_post_identity():
+    url = "https://www.uupdump.net/download.php?id=abc&pack=pt-br"
+    rule = apply_http_site_rule(url, {"Cookie": "session=123"}, 8)
+    assert rule.action == "uupdump_post"
+    assert rule.url == "https://uupdump.net/get.php?id=abc&pack=pt-br"
+    assert rule.subworkerCount == 1
+    assert rule.requestBody == UUPDUMP_BODY
+    assert rule.requestContentType == UUPDUMP_CONTENT_TYPE
+    assert rule.headers["Referer"] == "https://uupdump.net/download.php?id=abc&pack=pt-br"
+    assert rule.headers["Origin"] == "https://uupdump.net"
+    assert rule.headers["Cookie"] == "session=123"
+
+
+def test_uupdump_content_disposition_filename():
+    assert _filename_from_content_disposition('attachment; filename="26100.1_amd64_pt-br_multi.iso"') == "26100.1_amd64_pt-br_multi.iso"
+
+
+def test_uupdump_content_disposition_rfc2231_filename():
+    assert _filename_from_content_disposition("attachment; filename*=UTF-8''Windows%2011%20pt-BR.iso") == "Windows 11 pt-BR.iso"
+
+
+def test_similar_uupdump_hostname_does_not_match():
+    rule = apply_http_site_rule("https://uupdump.net.example.com/download.php?id=abc", {}, 8)
+    assert rule.action == "standard"
+
+
+def test_pixeldrain_forces_one_connection():
+    rule = apply_http_site_rule("https://pixeldrain.com/api/file/FhcC8Fyd?download", {}, 8)
+    assert rule.action == "single_connection"
+    assert rule.subworkerCount == 1
+
+
+def test_pixeldrain_subdomain_also_matches():
+    rule = apply_http_site_rule("https://cdn.pixeldrain.com/api/file/example", {}, 16)
+    assert rule.action == "single_connection"
+    assert rule.subworkerCount == 1


### PR DESCRIPTION
## Summary

This PR contains only the site-specific HTTP fixes for UUPDump and Pixeldrain, plus focused tests.

### UUPDump
- normalize `download.php` / `get.php` to the required `get.php` endpoint
- use POST with `autodl=2&updates=1`
- send Referer, Origin and form content type
- avoid GET/Range probing on the POST-only endpoint
- use the server-provided filename from Content-Disposition when available

### Pixeldrain
- force one HTTP connection/subworker
- disable dynamic worker reassignment and automatic speed-up for the task

### Tests
- UUPDump URL/request normalization
- Content-Disposition filename parsing
- hostname safety
- Pixeldrain single-connection behavior

No unrelated changes from my other downloader fork are included.